### PR TITLE
Enabled edge connections to diagonal entries in `matrix_to_graph`

### DIFF
--- a/src/DataGraphs.jl
+++ b/src/DataGraphs.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
 export DataGraph, DataDiGraph, add_node!, add_node_data!, add_edge_data!, adjacency_matrix
 export get_EC, matrix_to_graph, symmetric_matrix_to_graph, mvts_to_graph, tensor_to_graph
 export filter_nodes, filter_edges, run_EC_on_nodes, run_EC_on_edges, aggregate, average_degree
-export get_node_data, get_edge_data, ne, nn, nv
+export get_node_data, get_edge_data, ne, nn, nv, matrix_to_graph_diagonal
 
 abstract type AbstractDataGraph{T} <: Graphs.AbstractGraph{T} end
 

--- a/src/DataGraphs.jl
+++ b/src/DataGraphs.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
 export DataGraph, DataDiGraph, add_node!, add_node_data!, add_edge_data!, adjacency_matrix
 export get_EC, matrix_to_graph, symmetric_matrix_to_graph, mvts_to_graph, tensor_to_graph
 export filter_nodes, filter_edges, run_EC_on_nodes, run_EC_on_edges, aggregate, average_degree
-export get_node_data, get_edge_data, ne, nn, nv, matrix_to_graph_diagonal
+export get_node_data, get_edge_data, ne, nn, nv
 
 abstract type AbstractDataGraph{T} <: Graphs.AbstractGraph{T} end
 


### PR DESCRIPTION
Added a boolean argument to `matrix_to_graph` called `diagonal`. When `diagonal = true`, calling `matrix_to_graph` also adds edges to the diagonal elements of the matrix. For example, entry (i,j) will be connected to entry (i - 1, j-1), (i + 1, j - 1), etc. where applicable. 