### PR TITLE
Removed node positions and added dataset addition APIs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,12 @@ authors = ["dlcole3 <dlcole3@wisc.edu> and contributors"]
 version = "0.1.0"
 
 [deps]
-GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-GeometryBasics = "0.4.3"
 Graphs = "1.7.2"
 julia = "^1.7.0"
 

--- a/src/DataGraphs.jl
+++ b/src/DataGraphs.jl
@@ -13,7 +13,7 @@ export get_node_data, get_edge_data, ne, nn, nv, remove_node!, remove_edge!
 export add_node_attribute!, add_edge_attribute!, has_edge, has_node, has_path
 export get_node_attributes, get_edge_attributes, get_path
 export nodes_to_index, index_to_nodes, average_degree
-export rename_node_attribute!, rename_edge_attribute!
+export rename_node_attribute!, rename_edge_attribute!, add_node_dataset!, add_edge_dataset!
 
 abstract type AbstractDataGraph{T} <: Graphs.AbstractGraph{T} end
 

--- a/src/DataGraphs.jl
+++ b/src/DataGraphs.jl
@@ -13,6 +13,7 @@ export get_node_data, get_edge_data, ne, nn, nv, remove_node!, remove_edge!
 export add_node_attribute!, add_edge_attribute!, has_edge, has_node, has_path
 export get_node_attributes, get_edge_attributes, get_path
 export nodes_to_index, index_to_nodes, average_degree
+export rename_node_attribute!, rename_edge_attribute!
 
 abstract type AbstractDataGraph{T} <: Graphs.AbstractGraph{T} end
 
@@ -121,8 +122,6 @@ mutable struct DataGraph{T, T1, T2, M1, M2} <: AbstractDataGraph{T}
 
     node_data::NodeData{T, T1, M1}
     edge_data::EdgeData{T, T2, M2}
-
-    node_positions::Array{Union{GeometryBasics.Point{2,Float64}, Array{Float64, 2}},1}
 end
 
 """
@@ -150,8 +149,6 @@ mutable struct DataDiGraph{T, T1, T2, M1, M2} <: AbstractDataGraph{T}
 
     node_data::NodeData{T, T1, M1}
     edge_data::EdgeData{T, T2, M2}
-
-    node_positions::Array{Union{GeometryBasics.Point{2,Float64}, Array{Float64, 2}},1}
 end
 
 """

--- a/src/DataGraphs.jl
+++ b/src/DataGraphs.jl
@@ -3,14 +3,13 @@ module DataGraphs
 using Graphs
 using SparseArrays
 using Statistics
-using GeometryBasics
 using LinearAlgebra
 
 export DataGraph, DataDiGraph, add_node!, add_node_data!, add_edge_data!, adjacency_matrix
 export get_EC, matrix_to_graph, symmetric_matrix_to_graph, mvts_to_graph, tensor_to_graph
 export filter_nodes, filter_edges, run_EC_on_nodes, run_EC_on_edges, aggregate
 export get_node_data, get_edge_data, ne, nn, nv, remove_node!, remove_edge!
-export add_node_attribute!, add_edge_attribute!, has_edge, has_node, has_path
+export add_node_attribute!, add_edge_attribute!, has_edge, has_node, has_pathG
 export get_node_attributes, get_edge_attributes, get_path
 export nodes_to_index, index_to_nodes, average_degree
 export rename_node_attribute!, rename_edge_attribute!, add_node_dataset!, add_edge_dataset!

--- a/src/datadigraphs/core.jl
+++ b/src/datadigraphs/core.jl
@@ -219,7 +219,7 @@ function add_edge_data!(dg::DataDiGraph, edge::Tuple{Any, Any}, edge_weight::T, 
 end
 
 
-function add_edge_dataset!(dg::DataDiGraph, edge_list::Vector{Tuple}, weight_list::Vector, attribute::String)
+function add_edge_dataset!(dg::DataDiGraph, edge_list::Vector, weight_list::Vector, attribute::String)
     edges         = dg.edges
     attributes    = dg.edge_data.attributes
     edge_map      = dg.edge_map
@@ -296,7 +296,7 @@ function add_edge_dataset!(dg::DataDiGraph, weight_list::Vector, attribute::Stri
         dg.edge_data.data = edge_data
         return true
     else
-        for i in 1:length(edge_list)
+        for i in 1:length(edges)
             edge_data[i, attribute_map[attribute]] = weight_list[i]
         end
         return true
@@ -313,7 +313,7 @@ function add_edge_dataset!(dg::DataDiGraph, weight_dict::Dict, attribute::String
 
     edge_keys = keys(weight_dict)
 
-    if !(all(x -> (node_map[x[1]], node_map[x[2]]) in edges, edge_list), edge_keys)
+    if !(all(x -> (node_map[x[1]], node_map[x[2]]) in edges, edge_keys))
         error("edge key(s) in weight dict contains edges not in datagraph")
     end
 

--- a/src/datadigraphs/core.jl
+++ b/src/datadigraphs/core.jl
@@ -219,12 +219,13 @@ function add_edge_data!(dg::DataDiGraph, edge::Tuple{Any, Any}, edge_weight::T, 
 end
 
 
-function add_edge_data!(dg::DataDiGraph, edge_list::Vector{Tuple{Any, Any}}, weight_list::Vector{Any}, attribute::String)
+function add_edge_dataset!(dg::DataDiGraph, edge_list::Vector{Tuple}, weight_list::Vector, attribute::String)
     edges         = dg.edges
     attributes    = dg.edge_data.attributes
     edge_map      = dg.edge_map
     node_map      = dg.node_map
     attribute_map = dg.edge_data.attribute_map
+    edge_data     = get_edge_data(dg)
 
     if length(edge_list) != length(weight_list)
         error("edge list and weight list have different lengths")
@@ -263,12 +264,13 @@ function add_edge_data!(dg::DataDiGraph, edge_list::Vector{Tuple{Any, Any}}, wei
     end
 end
 
-function add_edge_data!(dg::DataGraph, weight_list::Vector{Any}, attribute::String)
+function add_edge_dataset!(dg::DataDiGraph, weight_list::Vector, attribute::String)
     edges         = dg.edges
     attributes    = dg.edge_data.attributes
     edge_map      = dg.edge_map
     node_map      = dg.node_map
     attribute_map = dg.edge_data.attribute_map
+    edge_data     = get_edge_data(dg)
 
     if length(edges) != length(weight_list)
         error("weight list is not the same length as number of edges")
@@ -301,16 +303,17 @@ function add_edge_data!(dg::DataGraph, weight_list::Vector{Any}, attribute::Stri
     end
 end
 
-function add_edge_data!(dg::DataGraph, weight_dict::Dict{Tuple{Any, Any}, Any}, attribute::String)
+function add_edge_dataset!(dg::DataDiGraph, weight_dict::Dict, attribute::String)
     edges         = dg.edges
     attributes    = dg.edge_data.attributes
     edge_map      = dg.edge_map
     node_map      = dg.node_map
     attribute_map = dg.edge_data.attribute_map
+    edge_data     = get_edge_data(dg)
 
     edge_keys = keys(weight_dict)
 
-    if !(all(x -> (node_map[x[1]], node_map[x[2]]) in edges, edge_list), edge_keys))
+    if !(all(x -> (node_map[x[1]], node_map[x[2]]) in edges, edge_list), edge_keys)
         error("edge key(s) in weight dict contains edges not in datagraph")
     end
 

--- a/src/datadigraphs/core.jl
+++ b/src/datadigraphs/core.jl
@@ -27,8 +27,6 @@ function DataDiGraph{T, T1, T2, M1, M2}() where {T <: Integer, T1, T2,  M1 <: Ma
     node_data = M1(undef, 0, 0)
     edge_data = M2(undef, 0, 0)
 
-    node_positions = [[0.0 0.0]]
-
     g = SimpleDiGraph(ne, fadjlist, badjlist)
 
     node_data_struct = NodeData(node_attributes, node_attribute_map, node_data)
@@ -36,7 +34,7 @@ function DataDiGraph{T, T1, T2, M1, M2}() where {T <: Integer, T1, T2,  M1 <: Ma
 
     DataDiGraph{T, T1, T2, M1, M2}(
         g, nodes, edges, node_map, edge_map,
-        node_data_struct, edge_data_struct, node_positions
+        node_data_struct, edge_data_struct
     )
 end
 
@@ -168,46 +166,6 @@ function add_edge!(dg::DataDiGraph, edge::Tuple{Any, Any})
     DataGraphs.add_edge!(dg, edge[1], edge[2])
 end
 
-
-"""
-    add_node_data!(datadigraph, node_name, node_weight, attribute_name)
-
-Add a weight value for the given node name in the DataDiGraph object. User must pass an "attribute
-name" for the given weight. All other nodes that do not have a node_weight value defined for
-that attribute name default to a value of zero.
-"""
-function add_node_data!(dg::DataDiGraph, node::Any, node_weight::Number, attribute::String = "weight")
-    nodes         = dg.nodes
-    attributes    = dg.node_data.attributes
-    node_map      = dg.node_map
-    node_data     = dg.node_data.data
-    attribute_map = dg.node_data.attribute_map
-
-    if !(node in nodes)
-        error("node does not exist in graph")
-    end
-
-    if length(attributes) < 1
-        node_data = Array{eltype(dg.node_data.data)}(undef, length(nodes), 0)
-        dg.node_data.data = node_data
-    end
-
-    if !(attribute in attributes)
-        # Add new column to node_weight array
-        push!(attributes, attribute)
-        attribute_map[attribute] = length(attributes)
-        new_col = fill(0, (length(nodes), 1))
-        node_data = hcat(node_data, new_col)
-        node_data[node_map[node], attribute_map[attribute]] = node_weight
-        dg.node_data.data = node_data
-        return true
-    else
-        node_data[node_map[node], attribute_map[attribute]] = node_weight
-        return true
-    end
-end
-
-
 """
     add_edge_data!(datadigraph, node_name1, node_name2, edge_weight, attribute_name)
     add_edge_data!(datadigraph, edge, edge_weight, attribute_name)
@@ -240,10 +198,11 @@ function add_edge_data!(dg::DataDiGraph, node1::Any, node2::Any, edge_weight::T,
 
     if !(attribute in attributes)
         edge_data = dg.edge_data.data
+        edge_type = eltype(edge_data)
         # Add new column to node_weight array
         push!(attributes, attribute)
         attribute_map[attribute] = length(attributes)
-        new_col = fill(0, (length(edges), 1))
+        new_col = fill(edge_type(0), (length(edges), 1))
         edge_data = hcat(edge_data, new_col)
         edge_data[edge_map[edge], attribute_map[attribute]] = edge_weight
         dg.edge_data.data = edge_data
@@ -257,4 +216,130 @@ end
 
 function add_edge_data!(dg::DataDiGraph, edge::Tuple{Any, Any}, edge_weight::T, attribute::String = "weight") where {T <: Real}
     add_edge_data!(dg, edge[1], edge[2], edge_weight, attribute)
+end
+
+
+function add_edge_data!(dg::DataDiGraph, edge_list::Vector{Tuple{Any, Any}}, weight_list::Vector{Any}, attribute::String)
+    edges         = dg.edges
+    attributes    = dg.edge_data.attributes
+    edge_map      = dg.edge_map
+    node_map      = dg.node_map
+    attribute_map = dg.edge_data.attribute_map
+
+    if length(edge_list) != length(weight_list)
+        error("edge list and weight list have different lengths")
+    end
+
+    if !(all(x -> (node_map[x[1]], node_map[x[2]]) in edges, edge_list))
+        error("edge(s) in edge_list does not exist in datagraph")
+    end
+
+    if length(attributes) == 0
+        edge_data = Array{eltype(dg.edge_data.data)}(undef, length(edges), 0)
+        dg.edge_data.data = edge_data
+    end
+
+    if !(attribute in attributes)
+        edge_data = dg.edge_data.data
+        T = eltype(edge_data)
+        # Add new column to node_weight array
+        push!(attributes, attribute)
+        attribute_map[attribute] = length(attributes)
+        new_col = fill(T(0), (length(edges), 1))
+        edge_data = hcat(edge_data, new_col)
+
+        for i in 1:length(edge_list)
+            edge = (node_map[edge_list[i][1]], node_map[edge_list[i][2]])
+            edge_data[edge_map[edge], attribute_map[attribute]] = weight_list[i]
+        end
+        dg.edge_data.data = edge_data
+        return true
+    else
+        for i in 1:length(edge_list)
+            edge = (node_map[edge_list[i][1]], node_map[edge_list[i][2]])
+            edge_data[edge_map[edge], attribute_map[attribute]] = weight_list[i]
+        end
+        return true
+    end
+end
+
+function add_edge_data!(dg::DataGraph, weight_list::Vector{Any}, attribute::String)
+    edges         = dg.edges
+    attributes    = dg.edge_data.attributes
+    edge_map      = dg.edge_map
+    node_map      = dg.node_map
+    attribute_map = dg.edge_data.attribute_map
+
+    if length(edges) != length(weight_list)
+        error("weight list is not the same length as number of edges")
+    end
+
+    if length(attributes) == 0
+        edge_data = Array{eltype(dg.edge_data.data)}(undef, length(edges), 0)
+        dg.edge_data.data = edge_data
+    end
+
+    if !(attribute in attributes)
+        edge_data = dg.edge_data.data
+        T = eltype(edge_data)
+        # Add new column to node_weight array
+        push!(attributes, attribute)
+        attribute_map[attribute] = length(attributes)
+        new_col = fill(T(0), (length(edges), 1))
+        edge_data = hcat(edge_data, new_col)
+
+        for i in 1:length(edges)
+            edge_data[i, attribute_map[attribute]] = weight_list[i]
+        end
+        dg.edge_data.data = edge_data
+        return true
+    else
+        for i in 1:length(edge_list)
+            edge_data[i, attribute_map[attribute]] = weight_list[i]
+        end
+        return true
+    end
+end
+
+function add_edge_data!(dg::DataGraph, weight_dict::Dict{Tuple{Any, Any}, Any}, attribute::String)
+    edges         = dg.edges
+    attributes    = dg.edge_data.attributes
+    edge_map      = dg.edge_map
+    node_map      = dg.node_map
+    attribute_map = dg.edge_data.attribute_map
+
+    edge_keys = keys(weight_dict)
+
+    if !(all(x -> (node_map[x[1]], node_map[x[2]]) in edges, edge_list), edge_keys))
+        error("edge key(s) in weight dict contains edges not in datagraph")
+    end
+
+    if length(attributes) == 0
+        edge_data = Array{eltype(dg.edge_data.data)}(undef, length(edges), 0)
+        dg.edge_data.data = edge_data
+    end
+
+    if !(attribute in attributes)
+        edge_data = dg.edge_data.data
+        T = eltype(edge_data)
+        # Add new column to node_weight array
+        push!(attributes, attribute)
+        attribute_map[attribute] = length(attributes)
+        new_col = fill(T(0), (length(edges), 1))
+        edge_data = hcat(edge_data, new_col)
+
+        for i in edge_keys
+            edge_index = edge_map[(node_map[i[1]], node_map[i[2]])]
+            edge_data[edge_index, attribute_map[attribute]] = weight_dict[i]
+        end
+
+        dg.edge_data.data = edge_data
+        return true
+    else
+        for i in edge_keys
+            edge_index = edge_map[(node_map[i[1]], node_map[i[2]])]
+            edge_data[edge_index, attribute_map[attribute]] = weight_dict[i]
+        end
+        return true
+    end
 end

--- a/src/datadigraphs/utils.jl
+++ b/src/datadigraphs/utils.jl
@@ -16,7 +16,6 @@ function filter_nodes(dg::DataDiGraph, filter_val::R; attribute::String=dg.node_
     edge_data          = dg.edge_data.data
     edge_map           = dg.edge_map
     edges              = dg.edges
-    node_positions     = dg.node_positions
 
     if length(node_attributes) == 0
         error("No node weights are defined")
@@ -38,13 +37,6 @@ function filter_nodes(dg::DataDiGraph, filter_val::R; attribute::String=dg.node_
 
     new_nodes     = nodes[bool_vec]
     new_node_data = node_data[bool_vec, :]
-
-    if length(node_positions) > 0 && length(node_positions) == length(nodes)
-        new_node_pos = node_positions[bool_vec]
-        new_dg.node_positions  = new_node_pos
-    else
-        new_node_pos = [[0.0 0.0]]
-    end
 
     new_node_map = Dict()
 
@@ -97,7 +89,6 @@ function filter_nodes(dg::DataDiGraph, filter_val::R; attribute::String=dg.node_
     new_dg.node_data.attributes = node_attributes
     new_dg.edge_data.attributes = edge_attributes
     new_dg.node_data.data       = new_node_data
-    new_dg.node_positions       = new_node_pos
     new_dg.node_data.attribute_map = dg.node_data.attribute_map
 
     return new_dg
@@ -167,7 +158,6 @@ function filter_edges(dg::DataDiGraph, filter_val::R; attribute::String = dg.edg
     new_dg.edge_map             = new_edge_map
     new_dg.node_data.attributes = node_attributes
     new_dg.edge_data.attributes = edge_attributes
-    new_dg.node_positions       = dg.node_positions
     new_dg.node_data.data       = dg.node_data.data
 
     new_dg.node_data.attribute_map = dg.node_data.attribute_map
@@ -192,7 +182,6 @@ function remove_node!(dg::DataDiGraph, node_name)
     edge_map = dg.edge_map
     node_data = dg.node_data.data
     edge_data = dg.edge_data.data
-    node_pos  = dg.node_positions
 
     node_num  = node_map[node_name]
     node_fadj = dg.g.fadjlist[node_num]
@@ -202,14 +191,6 @@ function remove_node!(dg::DataDiGraph, node_name)
     old_node_length = length(nodes)
     last_node_fadj  = dg.g.fadjlist[old_node_length]
     last_node_badj  = dg.g.badjlist[old_node_length]
-
-    if length(node_pos) == length(nodes)
-        last_node_pos = node_pos[old_node_length]
-        deleteat!(node_pos, node_num)
-        pop!(node_pos)
-        insert!(node_pos, node_num, last_node_pos)
-        dg.node_positions = node_pos
-    end
 
     if length(dg.node_data.attributes) > 0
         node_data_order = [i for i in 1:(length(nodes) - 1)]
@@ -353,7 +334,6 @@ function aggregate(dg::DataDiGraph, node_set, new_name)
     node_data          = dg.node_data.data
     node_attributes    = dg.node_data.attributes
     node_attribute_map = dg.node_data.attribute_map
-    node_positions     = dg.node_positions
 
     if !(issubset(node_set, nodes))
         undef_nodes = setdiff(node_set, nodes)
@@ -404,22 +384,6 @@ function aggregate(dg::DataDiGraph, node_set, new_name)
         new_dg.node_data.attributes    = node_attributes
         new_dg.node_data.attribute_map = node_attribute_map
         new_dg.node_data.data          = new_node_data
-    end
-
-    if length(node_positions) > 1
-        new_node_positions = node_positions[indices_to_keep]
-        old_pos            = node_positions[agg_node_indices]
-
-        xvals = 0
-        yvals = 0
-
-        for j in 1:length(node_set)
-            xvals += old_pos[j][1]
-            yvals += old_pos[j][2]
-        end
-
-        push!(new_node_positions, Point(xvals/length(node_set), yvals/length(node_set)))
-        new_dg.node_positions = new_node_positions
     end
 
     edges              = dg.edges

--- a/src/datagraphs/core.jl
+++ b/src/datagraphs/core.jl
@@ -251,7 +251,7 @@ Add a weight value for the given node name in the DataGraph object. User must pa
 name" for the given weight. All other nodes that do not have a node_weight value defined for
 that attribute name default to a value of zero.
 """
-function add_node_data!(dg::D, node::Any, node_weight::Any, attribute::String) where {D <: DataGraphUnion}
+function add_node_data!(dg::D, node::Any, node_weight::Any, attribute::String = "weight") where {D <: DataGraphUnion}
     nodes         = dg.nodes
     attributes    = dg.node_data.attributes
     node_map      = dg.node_map
@@ -284,14 +284,14 @@ function add_node_data!(dg::D, node::Any, node_weight::Any, attribute::String) w
 end
 
 """
-    add_node_data!(dg::D, node_list, weight_list, attribute) where {D <: DataGraphUnion}
+    add_node_dataset!(dg::D, node_list, weight_list, attribute) where {D <: DataGraphUnion}
 
 Add the node data in `weight_list` to `dg`. `node_list` is a list of nodes in `dg` and
 `weight_list` is a list of values/things to be saved as node data under the name `attribute`.
 `node_list` and `weight_list` must have the same length, and entries of `weight_list` will
 be added to the corresponding node in `node_list`
 """
-function add_node_data!(dg::D, node_list::Vector{Any}, weight_list::Vector{Any}, attribute::String) where {D <: DataGraphUnion}
+function add_node_dataset!(dg::D, node_list::Vector, weight_list::Vector, attribute::String) where {D <: DataGraphUnion}
     nodes         = dg.nodes
     attributes    = dg.node_data.attributes
     node_map      = dg.node_map
@@ -334,13 +334,13 @@ function add_node_data!(dg::D, node_list::Vector{Any}, weight_list::Vector{Any},
 end
 
 """
-    add_node_data!(dg::D, weight_list, attribute) where {D <: DataGraphUnion}
+    add_node_dataset!(dg::D, weight_list, attribute) where {D <: DataGraphUnion}
 
 Add the entries of `weight_list` as node data on `dg` under the name `attribute`. `weight_list`
 must be the same length as the number of nodes in `dg`. Entries of `weight_list` will be
 added as node data in the order that nodes are listed in `dg.nodes`.
 """
-function add_node_data!(dg::D, weight_list::Vector{Any}, attribute::String) where {D <: DataGraphUnion}
+function add_node_dataset!(dg::D, weight_list::Vector, attribute::String) where {D <: DataGraphUnion}
     nodes         = dg.nodes
     attributes    = dg.node_data.attributes
     node_data     = dg.node_data.data
@@ -379,12 +379,12 @@ function add_node_data!(dg::D, weight_list::Vector{Any}, attribute::String) wher
 end
 
 """
-    add_node_data!(dg::D, weight_dict, attribute) where {D <: DataGraphUnion}
+    add_node_dataset!(dg::D, weight_dict, attribute) where {D <: DataGraphUnion}
 
 Add the data in `weight_dict` as node data on `dg` under the name `attribute`. `weight_dict`
 must contain keys that correspond to the node names in `dg.nodes`.
 """
-function add_node_data!(dg::D, weight_dict::Dict{Any, Any}, attribute::String) where {D <: DataGraphUnion}
+function add_node_dataset!(dg::D, weight_dict::Dict, attribute::String) where {D <: DataGraphUnion}
     nodes         = dg.nodes
     node_map      = dg.node_map
     attributes    = dg.node_data.attributes
@@ -476,19 +476,20 @@ function add_edge_data!(dg::DataGraph, edge::Tuple{Any, Any}, edge_weight::Any, 
     add_edge_data!(dg, edge[1], edge[2], edge_weight, attribute)
 end
 """
-    add_edge_data!(dg::D, edge_list, weight_list, attribute) where {D <: DataGraphUnion}
+    add_edge_dataset!(dg::D, edge_list, weight_list, attribute) where {D <: DataGraphUnion}
 
 Add the edge data in `weight_list` to `dg`. `edge_list` is a list of edges (as node names,
 not integers) in `dg` and `weight_list` is a list of data/objects to be saved as edge data
 under the name `attribute`. `edge_list` and `weight_list` must have the same length, and
 entries of `weight_list` will be added to the corresponding edge in `edge_list`
 """
-function add_edge_data!(dg::DataGraph, edge_list::Vector{Tuple{Any, Any}}, weight_list::Vector{Any}, attribute::String)
+function add_edge_dataset!(dg::DataGraph, edge_list::Vector, weight_list::Vector, attribute::String)
     edges         = dg.edges
     attributes    = dg.edge_data.attributes
     edge_map      = dg.edge_map
     node_map      = dg.node_map
     attribute_map = dg.edge_data.attribute_map
+    edge_data     = dg.edge_data.data
 
     if length(edge_list) != length(weight_list)
         error("edge list and weight list have different lengths")
@@ -528,18 +529,19 @@ function add_edge_data!(dg::DataGraph, edge_list::Vector{Tuple{Any, Any}}, weigh
 end
 
 """
-    add_edge_data!(dg::D, weight_list, attribute) where {D <: DataGraphUnion}
+    add_edge_dataset!(dg::D, weight_list, attribute) where {D <: DataGraphUnion}
 
 Add the entries of `weight_list` as edge data on `dg` under the name `attribute`. `weight_list`
 must be the same length as the number of edges in `dg`. Entries of `weight_list` will be
 added as edge data in the order that edges are listed in `dg.edges`.
 """
-function add_edge_data!(dg::DataGraph, weight_list::Vector{Any}, attribute::String)
+function add_edge_dataset!(dg::DataGraph, weight_list::Vector, attribute::String)
     edges         = dg.edges
     attributes    = dg.edge_data.attributes
     edge_map      = dg.edge_map
     node_map      = dg.node_map
     attribute_map = dg.edge_data.attribute_map
+    edge_data     = get_edge_data(dg)
 
     if length(edges) != length(weight_list)
         error("weight list is not the same length as number of edges")
@@ -565,7 +567,7 @@ function add_edge_data!(dg::DataGraph, weight_list::Vector{Any}, attribute::Stri
         dg.edge_data.data = edge_data
         return true
     else
-        for i in 1:length(edge_list)
+        for i in 1:length(edges)
             edge_data[i, attribute_map[attribute]] = weight_list[i]
         end
         return true
@@ -573,17 +575,18 @@ function add_edge_data!(dg::DataGraph, weight_list::Vector{Any}, attribute::Stri
 end
 
 """
-    add_edge_data!(dg::D, weight_dict, attribute) where {D <: DataGraphUnion}
+    add_edge_dataset!(dg::D, weight_dict, attribute) where {D <: DataGraphUnion}
 
 Add the data in `weight_dict` as edge data on `dg` under the name `attribute`. `weight_dict`
 must contain keys that correspond to the edges (as node names, not integers) in `dg.edges`.
 """
-function add_edge_data!(dg::DataGraph, weight_dict::Dict{Tuple{Any, Any}, Any}, attribute::String)
+function add_edge_dataset!(dg::DataGraph, weight_dict::Dict, attribute::String)
     edges         = dg.edges
     attributes    = dg.edge_data.attributes
     edge_map      = dg.edge_map
     node_map      = dg.node_map
     attribute_map = dg.edge_data.attribute_map
+    edge_data     = get_edge_data(dg)
 
     edge_keys = keys(weight_dict)
 

--- a/src/datagraphs/core.jl
+++ b/src/datagraphs/core.jl
@@ -3,7 +3,7 @@
 
 Constructor for building a DataGraph object from a list of nodes and edges. Key word arguments
 include `ne`, `fadjlist`, `node_attributes`, `edge_attributes`, `node_map`, `edge_map`,
-`node_data`, `edge_data`, and `node_positions`.
+`node_data`, and `edge_data`.
 """
 function DataGraph(
     nodes::Vector{Any},
@@ -15,8 +15,7 @@ function DataGraph(
     node_map::Dict{Any, Int} = Dict{Any, Int}(),
     edge_map::Dict{Tuple{T}, Int} = Dict{Any, Int}(),
     node_data::M1 = Array{Float64}(undef, 0, 0),
-    edge_data::M2 = Array{Float64}(undef, 0, 0),
-    node_positions = [[0.0 0.0]]
+    edge_data::M2 = Array{Float64}(undef, 0, 0)
 ) where {T <: Int, T1, T2, M1 <: Matrix{T1}, M2 <: Matrix{T2}}
 
     if length(edges) != ne
@@ -47,7 +46,7 @@ function DataGraph(
 
     DataGraph{T, M1, M2}(
         g, nodes, edges, node_map, edge_map,
-        node_data_struct, edge_data_struct, node_positions
+        node_data_struct, edge_data_struct
     )
 end
 
@@ -79,8 +78,6 @@ function DataGraph{T, T1, T2, M1, M2}() where {T <: Integer, T1, T2,  M1 <: Abst
     node_data = M1(undef, 0, 0)
     edge_data = M2(undef, 0, 0)
 
-    node_positions = [[0.0 0.0]]
-
     g = SimpleGraph(ne, fadjlist)
 
     node_data_struct = NodeData(node_attributes, node_attribute_map, node_data)
@@ -88,7 +85,7 @@ function DataGraph{T, T1, T2, M1, M2}() where {T <: Integer, T1, T2,  M1 <: Abst
 
     DataGraph{T, T1, T2, M1, M2}(
         g, nodes, edges, node_map, edge_map,
-        node_data_struct, edge_data_struct, node_positions
+        node_data_struct, edge_data_struct
     )
 end
 
@@ -138,6 +135,16 @@ function _get_edge(node1_index, node2_index)
     end
 end
 
+function _get_edge(node_map, edge::Tuple{Any, Any})
+    node1_index = node_map[edge[1]]
+    node2_index = node_map[edge[2]]
+
+    if node2_index > node1_index
+        return (node1_index, node2_index)
+    else
+        return (node2_index, node1_index)
+    end
+end
 
 """
     add_node!(dg, node_name)
@@ -177,7 +184,6 @@ function add_node!(
        return false
     end
 end
-
 
 """
     add_edge!(dg, node_1, node_2)
@@ -239,13 +245,13 @@ function add_edge!(dg::DataGraph, edge::Tuple{Any, Any})
 end
 
 """
-    add_node_data!(datagraph, node_name, node_weight, attribute_name)
+    add_node_data!(dg::D, node_name, node_weight, attribute_name) where {D <: DataGraphUnion}
 
 Add a weight value for the given node name in the DataGraph object. User must pass an "attribute
 name" for the given weight. All other nodes that do not have a node_weight value defined for
 that attribute name default to a value of zero.
 """
-function add_node_data!(dg::DataGraph, node::Any, node_weight::T, attribute::String) where {T <: Real}
+function add_node_data!(dg::D, node::Any, node_weight::Any, attribute::String) where {D <: DataGraphUnion}
     nodes         = dg.nodes
     attributes    = dg.node_data.attributes
     node_map      = dg.node_map
@@ -253,7 +259,7 @@ function add_node_data!(dg::DataGraph, node::Any, node_weight::T, attribute::Str
     attribute_map = dg.node_data.attribute_map
 
     if !(node in nodes)
-        error("node does not exist in graph")
+        error("$node does not exist in graph")
     end
 
     if length(attributes) < 1
@@ -263,15 +269,157 @@ function add_node_data!(dg::DataGraph, node::Any, node_weight::T, attribute::Str
 
     if !(attribute in attributes)
         # Add new column to node_weight array
+        T = eltype(node_data)
         push!(attributes, attribute)
         attribute_map[attribute] = length(attributes)
-        new_col = fill(0, (length(nodes), 1))
+        new_col = fill(T(0), (length(nodes), 1))
         node_data = hcat(node_data, new_col)
         node_data[node_map[node], attribute_map[attribute]] = node_weight
         dg.node_data.data = node_data
         return true
     else
         node_data[node_map[node], attribute_map[attribute]] = node_weight
+        return true
+    end
+end
+
+"""
+    add_node_data!(dg::D, node_list, weight_list, attribute) where {D <: DataGraphUnion}
+
+Add the node data in `weight_list` to `dg`. `node_list` is a list of nodes in `dg` and
+`weight_list` is a list of values/things to be saved as node data under the name `attribute`.
+`node_list` and `weight_list` must have the same length, and entries of `weight_list` will
+be added to the corresponding node in `node_list`
+"""
+function add_node_data!(dg::D, node_list::Vector{Any}, weight_list::Vector{Any}, attribute::String) where {D <: DataGraphUnion}
+    nodes         = dg.nodes
+    attributes    = dg.node_data.attributes
+    node_map      = dg.node_map
+    node_data     = dg.node_data.data
+    attribute_map = dg.node_data.attribute_map
+
+    if !(all(x -> x in nodes, node_list))
+        error("node_list contains nodes not in datagraph")
+    end
+
+    if length(node_list) != length(weight_list)
+        error("node and weight lists are different sizes")
+    end
+
+    if length(attributes) < 1
+        node_data = Array{eltype(dg.node_data.data)}(undef, length(nodes), 0)
+        dg.node_data.data = node_data
+    end
+
+    if !(attribute in attributes)
+        # Add new column to node_weight array
+        T = eltype(node_data)
+        push!(attributes, attribute)
+        attribute_map[attribute] = length(attributes)
+
+        new_col = fill(T(0), (length(nodes), 1))
+        node_data = hcat(node_data, new_col)
+        for i in 1:length(node_list)
+            node_data[node_map[node_list[i]], attribute_map[attribute]] = weight_list[i]
+        end
+        dg.node_data.data = node_data
+        return true
+    else
+        for i in 1:length(node_list)
+            node_data[node_map[node_list[i]], attribute_map[attribute]] = weight_list[i]
+        end
+        dg.node_data.data = node_data
+        return true
+    end
+end
+
+"""
+    add_node_data!(dg::D, weight_list, attribute) where {D <: DataGraphUnion}
+
+Add the entries of `weight_list` as node data on `dg` under the name `attribute`. `weight_list`
+must be the same length as the number of nodes in `dg`. Entries of `weight_list` will be
+added as node data in the order that nodes are listed in `dg.nodes`.
+"""
+function add_node_data!(dg::D, weight_list::Vector{Any}, attribute::String) where {D <: DataGraphUnion}
+    nodes         = dg.nodes
+    attributes    = dg.node_data.attributes
+    node_data     = dg.node_data.data
+    attribute_map = dg.node_data.attribute_map
+
+
+    if length(weight_list) != length(nodes)
+        error("weight list length not equal to the number of nodes")
+    end
+
+    if length(attributes) < 1
+        node_data = Array{eltype(dg.node_data.data)}(undef, length(nodes), 0)
+        dg.node_data.data = node_data
+    end
+
+    if !(attribute in attributes)
+        # Add new column to node_weight array
+        T = eltype(node_data)
+        push!(attributes, attribute)
+        attribute_map[attribute] = length(attributes)
+
+        new_col = fill(T(0), (length(nodes), 1))
+        node_data = hcat(node_data, new_col)
+        for i in 1:length(weight_list)
+            node_data[i, attribute_map[attribute]] = weight_list[i]
+        end
+        dg.node_data.data = node_data
+        return true
+    else
+        for i in 1:length(weight_list)
+            node_data[i, attribute_map[attribute]] = weight_list[i]
+        end
+        dg.node_data.data = node_data
+        return true
+    end
+end
+
+"""
+    add_node_data!(dg::D, weight_dict, attribute) where {D <: DataGraphUnion}
+
+Add the data in `weight_dict` as node data on `dg` under the name `attribute`. `weight_dict`
+must contain keys that correspond to the node names in `dg.nodes`.
+"""
+function add_node_data!(dg::D, weight_dict::Dict{Any, Any}, attribute::String) where {D <: DataGraphUnion}
+    nodes         = dg.nodes
+    node_map      = dg.node_map
+    attributes    = dg.node_data.attributes
+    node_data     = dg.node_data.data
+    attribute_map = dg.node_data.attribute_map
+
+    node_keys = keys(weight_dict)
+
+    if !(all(x -> x in nodes, node_keys))
+        error("node key(s) in weight dict contains nodes not in datagraph")
+    end
+
+    if length(attributes) < 1
+        node_data = Array{eltype(dg.node_data.data)}(undef, length(nodes), 0)
+        dg.node_data.data = node_data
+    end
+
+    if !(attribute in attributes)
+        # Add new column to node_weight array
+        T = eltype(node_data)
+        push!(attributes, attribute)
+        attribute_map[attribute] = length(attributes)
+
+        new_col = fill(T(0), (length(nodes), 1))
+        node_data = hcat(node_data, new_col)
+        for i in node_keys
+            node_data[node_map[i], attribute_map[attribute]] = weight_dict[i]
+        end
+        dg.node_data.data = node_data
+        return true
+    else
+        for i in node_keys
+            node_data[node_map[i], attribute_map[attribute]] = weight_dict[i]
+        end
+        dg.node_data.data = node_data
         return true
     end
 end
@@ -285,7 +433,7 @@ When using the second function, `edge` must be a tuple with two node names. User
 an "attribute name" for the given weight. All other edges that do not have an edge_weight
 value defined for that attribute name default to a value of zero.
 """
-function add_edge_data!(dg::DataGraph, node1::Any, node2::Any, edge_weight::T, attribute::String) where {T <: Real}
+function add_edge_data!(dg::DataGraph, node1::Any, node2::Any, edge_weight::Any, attribute::String)
     edges         = dg.edges
     attributes    = dg.edge_data.attributes
     edge_map      = dg.edge_map
@@ -308,10 +456,11 @@ function add_edge_data!(dg::DataGraph, node1::Any, node2::Any, edge_weight::T, a
 
     if !(attribute in attributes)
         edge_data = dg.edge_data.data
+        T = eltype(edge_data)
         # Add new column to node_weight array
         push!(attributes, attribute)
         attribute_map[attribute] = length(attributes)
-        new_col = fill(0, (length(edges), 1))
+        new_col = fill(T(0), (length(edges), 1))
         edge_data = hcat(edge_data, new_col)
         edge_data[edge_map[edge], attribute_map[attribute]] = edge_weight
         dg.edge_data.data = edge_data
@@ -323,6 +472,151 @@ function add_edge_data!(dg::DataGraph, node1::Any, node2::Any, edge_weight::T, a
     end
 end
 
-function add_edge_data!(dg::DataGraph, edge::Tuple{Any, Any}, edge_weight::T, attribute::String) where {T <: Real}
+function add_edge_data!(dg::DataGraph, edge::Tuple{Any, Any}, edge_weight::Any, attribute::String)
     add_edge_data!(dg, edge[1], edge[2], edge_weight, attribute)
+end
+"""
+    add_edge_data!(dg::D, edge_list, weight_list, attribute) where {D <: DataGraphUnion}
+
+Add the edge data in `weight_list` to `dg`. `edge_list` is a list of edges (as node names,
+not integers) in `dg` and `weight_list` is a list of data/objects to be saved as edge data
+under the name `attribute`. `edge_list` and `weight_list` must have the same length, and
+entries of `weight_list` will be added to the corresponding edge in `edge_list`
+"""
+function add_edge_data!(dg::DataGraph, edge_list::Vector{Tuple{Any, Any}}, weight_list::Vector{Any}, attribute::String)
+    edges         = dg.edges
+    attributes    = dg.edge_data.attributes
+    edge_map      = dg.edge_map
+    node_map      = dg.node_map
+    attribute_map = dg.edge_data.attribute_map
+
+    if length(edge_list) != length(weight_list)
+        error("edge list and weight list have different lengths")
+    end
+
+    if !(all(x -> _get_edge(node_map, x) in edges, edge_list))
+        error("edge(s) in edge_list does not exist in datagraph")
+    end
+
+    if length(attributes) == 0
+        edge_data = Array{eltype(dg.edge_data.data)}(undef, length(edges), 0)
+        dg.edge_data.data = edge_data
+    end
+
+    if !(attribute in attributes)
+        edge_data = dg.edge_data.data
+        T = eltype(edge_data)
+        # Add new column to node_weight array
+        push!(attributes, attribute)
+        attribute_map[attribute] = length(attributes)
+        new_col = fill(T(0), (length(edges), 1))
+        edge_data = hcat(edge_data, new_col)
+
+        for i in 1:length(edge_list)
+            edge = _get_edge(node_map, edge_list[i])
+            edge_data[edge_map[edge], attribute_map[attribute]] = weight_list[i]
+        end
+        dg.edge_data.data = edge_data
+        return true
+    else
+        for i in 1:length(edge_list)
+            edge = _get_edge(node_map, edge_list[i])
+            edge_data[edge_map[edge], attribute_map[attribute]] = weight_list[i]
+        end
+        return true
+    end
+end
+
+"""
+    add_edge_data!(dg::D, weight_list, attribute) where {D <: DataGraphUnion}
+
+Add the entries of `weight_list` as edge data on `dg` under the name `attribute`. `weight_list`
+must be the same length as the number of edges in `dg`. Entries of `weight_list` will be
+added as edge data in the order that edges are listed in `dg.edges`.
+"""
+function add_edge_data!(dg::DataGraph, weight_list::Vector{Any}, attribute::String)
+    edges         = dg.edges
+    attributes    = dg.edge_data.attributes
+    edge_map      = dg.edge_map
+    node_map      = dg.node_map
+    attribute_map = dg.edge_data.attribute_map
+
+    if length(edges) != length(weight_list)
+        error("weight list is not the same length as number of edges")
+    end
+
+    if length(attributes) == 0
+        edge_data = Array{eltype(dg.edge_data.data)}(undef, length(edges), 0)
+        dg.edge_data.data = edge_data
+    end
+
+    if !(attribute in attributes)
+        edge_data = dg.edge_data.data
+        T = eltype(edge_data)
+        # Add new column to node_weight array
+        push!(attributes, attribute)
+        attribute_map[attribute] = length(attributes)
+        new_col = fill(T(0), (length(edges), 1))
+        edge_data = hcat(edge_data, new_col)
+
+        for i in 1:length(edges)
+            edge_data[i, attribute_map[attribute]] = weight_list[i]
+        end
+        dg.edge_data.data = edge_data
+        return true
+    else
+        for i in 1:length(edge_list)
+            edge_data[i, attribute_map[attribute]] = weight_list[i]
+        end
+        return true
+    end
+end
+
+"""
+    add_edge_data!(dg::D, weight_dict, attribute) where {D <: DataGraphUnion}
+
+Add the data in `weight_dict` as edge data on `dg` under the name `attribute`. `weight_dict`
+must contain keys that correspond to the edges (as node names, not integers) in `dg.edges`.
+"""
+function add_edge_data!(dg::DataGraph, weight_dict::Dict{Tuple{Any, Any}, Any}, attribute::String)
+    edges         = dg.edges
+    attributes    = dg.edge_data.attributes
+    edge_map      = dg.edge_map
+    node_map      = dg.node_map
+    attribute_map = dg.edge_data.attribute_map
+
+    edge_keys = keys(weight_dict)
+
+    if !(all(x -> _get_edge(node_map, (x[1], x[2])) in edges, edge_keys))
+        error("edge key(s) in weight dict contains edges not in datagraph")
+    end
+
+    if length(attributes) == 0
+        edge_data = Array{eltype(dg.edge_data.data)}(undef, length(edges), 0)
+        dg.edge_data.data = edge_data
+    end
+
+    if !(attribute in attributes)
+        edge_data = dg.edge_data.data
+        T = eltype(edge_data)
+        # Add new column to node_weight array
+        push!(attributes, attribute)
+        attribute_map[attribute] = length(attributes)
+        new_col = fill(T(0), (length(edges), 1))
+        edge_data = hcat(edge_data, new_col)
+
+        for i in edge_keys
+            edge_index = edge_map[_get_edge(node_map, (i[1], i[2]))]
+            edge_data[edge_index, attribute_map[attribute]] = weight_dict[i]
+        end
+
+        dg.edge_data.data = edge_data
+        return true
+    else
+        for i in edge_keys
+            edge_index = edge_map[_get_edge(node_map, (i[1], i[2]))]
+            edge_data[edge_index, attribute_map[attribute]] = weight_dict[i]
+        end
+        return true
+    end
 end

--- a/src/datagraphs/utils.jl
+++ b/src/datagraphs/utils.jl
@@ -363,7 +363,6 @@ function filter_nodes(dg::DataGraph, filter_val::R; attribute::String=dg.node_da
     edge_data          = dg.edge_data.data
     edge_map           = dg.edge_map
     edges              = dg.edges
-    node_positions     = dg.node_positions
 
     if length(node_attributes) == 0
         error("No node weights are defined")
@@ -385,13 +384,6 @@ function filter_nodes(dg::DataGraph, filter_val::R; attribute::String=dg.node_da
 
     new_nodes     = nodes[bool_vec]
     new_node_data = node_data[bool_vec, :]
-
-    if length(node_positions) > 0 && length(node_positions) == length(nodes)
-        new_node_pos = node_positions[bool_vec]
-        new_dg.node_positions  = new_node_pos
-    else
-        new_node_pos = [[0.0 0.0]]
-    end
 
     new_node_map = Dict()
 
@@ -443,7 +435,6 @@ function filter_nodes(dg::DataGraph, filter_val::R; attribute::String=dg.node_da
     new_dg.node_data.attributes = node_attributes
     new_dg.edge_data.attributes = edge_attributes
     new_dg.node_data.data       = new_node_data
-    new_dg.node_positions       = new_node_pos
     new_dg.node_data.attribute_map = dg.node_data.attribute_map
 
     return new_dg
@@ -514,7 +505,6 @@ function filter_edges(dg::DataGraph, filter_val::R; attribute::String = dg.edge_
     new_dg.edge_map             = new_edge_map
     new_dg.node_data.attributes = node_attributes
     new_dg.edge_data.attributes = edge_attributes
-    new_dg.node_positions       = dg.node_positions
     new_dg.node_data.data       = dg.node_data.data
 
     new_dg.node_data.attribute_map = dg.node_data.attribute_map
@@ -612,7 +602,6 @@ function remove_node!(dg::DataGraph, node_name::Any)
     edge_map = dg.edge_map
     node_data = dg.node_data.data
     edge_data = dg.edge_data.data
-    node_pos  = dg.node_positions
 
     node_num  = node_map[node_name]
     node_fadj = dg.g.fadjlist[node_num]
@@ -620,14 +609,6 @@ function remove_node!(dg::DataGraph, node_name::Any)
     last_node_name  = nodes[length(nodes)]
     old_node_length = length(nodes)
     last_node_fadj  = dg.g.fadjlist[old_node_length]
-
-    if length(node_pos) == length(nodes)
-        last_node_pos = node_pos[old_node_length]
-        deleteat!(node_pos, node_num)
-        pop!(node_pos)
-        insert!(node_pos, node_num, last_node_pos)
-        dg.node_positions = node_pos
-    end
 
     if length(dg.node_data.attributes) > 0
         node_data_order = [i for i in 1:(length(nodes) - 1)]
@@ -758,7 +739,6 @@ function aggregate(dg::DataGraph, node_set, new_name)
     node_data          = dg.node_data.data
     node_attributes    = dg.node_data.attributes
     node_attribute_map = dg.node_data.attribute_map
-    node_positions     = dg.node_positions
 
     if !(issubset(node_set, nodes))
         undef_nodes = setdiff(node_set, nodes)
@@ -809,22 +789,6 @@ function aggregate(dg::DataGraph, node_set, new_name)
         new_dg.node_data.attributes    = node_attributes
         new_dg.node_data.attribute_map = node_attribute_map
         new_dg.node_data.data          = new_node_data
-    end
-
-    if length(node_positions) > 1
-        new_node_positions = node_positions[indices_to_keep]
-        old_pos            = node_positions[agg_node_indices]
-
-        xvals = 0
-        yvals = 0
-
-        for j in 1:length(node_set)
-            xvals += old_pos[j][1]
-            yvals += old_pos[j][2]
-        end
-
-        push!(new_node_positions, Point(xvals/length(node_set), yvals/length(node_set)))
-        new_dg.node_positions = new_node_positions
     end
 
     edges              = dg.edges

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -100,7 +100,12 @@ function add_node_attribute!(dg::D, attribute::String, default_weight = 0.0) whe
     node_data = get_node_data(dg)
     nodes = dg.nodes
 
-    new_col = fill(default_weight, (length(nodes,), 1))
+    if length(dg.node_data.attributes) == 0
+        M = typeof(node_data)
+        node_data = M(undef, length(nodes), 0)
+    end
+
+    new_col = fill(default_weight, (length(nodes), 1))
 
     node_data = hcat(node_data, new_col)
     push!(dg.node_data.attributes, attribute)
@@ -125,6 +130,11 @@ function add_edge_attribute!(dg::D, attribute::String, default_weight = 0) where
 
     edge_data = get_edge_data(dg)
     edges = dg.edges
+
+    if length(dg.edge_data.attributes) == 0
+        M = typeof(edge_data)
+        edge_data = M(undef, length(edges), 0)
+    end
 
     new_col = fill(default_weight, (length(edges), 1))
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -136,3 +136,52 @@ function add_edge_attribute!(dg::D, attribute::String, default_weight = 0) where
 
     return true
 end
+
+"""
+    rename_node_attribute!(dg::D, attribute, new_name) where {D <: DataGraphUnion}
+
+Rename the node data `attribute` as `new_name`. If `attribute` is not defined, returns an error.
+"""
+function rename_node_attribute!(dg::D, attribute::String, new_name::String) where {D <: DataGraphUnion}
+    node_attributes = dg.node_data.attributes
+    attribute_map = dg.node_data.attribute_map
+
+    println(attribute, node_attributes, attribute in node_attributes)
+    if !(attribute in node_attributes)
+        error("$attribute is not in the node data attributes")
+    end
+
+    attribute_loc = attribute_map[attribute]
+    delete!(attribute_map, attribute)
+    deleteat!(node_attributes, attribute_loc)
+
+    insert!(node_attributes, attribute_loc, new_name)
+    attribute_map[new_name] = attribute_loc
+
+    dg.node_data.attributes = node_attributes
+    dg.node_data.attribute_map = attribute_map
+end
+
+"""
+    rename_edge_attribute!(dg::D, attribute, new_name) where {D <: DataGraphUnion}
+
+Rename the edge data `attribute` as `new_name`. If `attribute` is not defined, returns an error.
+"""
+function rename_edge_attribute!(dg::D, attribute::String, new_name::String) where {D <: DataGraphUnion}
+    edge_attributes = dg.edge_data.attributes
+    attribute_map = dg.edge_data.attribute_map
+
+    if !(attribute in edge_attributes)
+        error("$attribute is not in the edge data attributes")
+    end
+
+    attribute_loc = attribute_map[attribute]
+    delete!(attribute_map, attribute)
+    deleteat!(edge_attributes, attribute_loc)
+
+    insert!(edge_attributes, attribute_loc, new_name)
+    attribute_map[new_name] = attribute_loc
+
+    dg.edge_data.attributes = edge_attributes
+    dg.edge_data.attribute_map = attribute_map
+end

--- a/test/DataDiGraph_interface_test.jl
+++ b/test/DataDiGraph_interface_test.jl
@@ -22,6 +22,9 @@ end
     @test_throws ErrorException get_edge_data(dg, 1, 6, "weight")
 end
 
+rename_node_attribute!(dg, "weight", "weight1")
+rename_edge_attribute!(dg, "weight", "weight1")
+
 @testset "interface test" begin
     @test DataGraphs.ne(dg) == length(dg.edges)
     @test DataGraphs.nv(dg) == length(dg.nodes)
@@ -32,4 +35,10 @@ end
     @test !(DataGraphs.has_edge(dg, 3, 1))
     @test_throws ErrorException DataGraphs.has_edge(dg, 7, 3)
     @test_throws ErrorException DataGraphs.has_edge(dg, 3, 7)
+    @test dg.node_data.attributes == ["weight1"]
+    @test dg.node_data.attribute_map["weight1"] == 1
+    @test dg.edge_data.attributes == ["weight1"]
+    @test dg.edge_data.attribute_map["weight1"] == 1
+    @test_throws ErrorException rename_node_attribute!(dg, "wrong_weight", "weight")
+    @test_throws ErrorException rename_edge_attribute!(dg, "wrong_weight", "weight")
 end

--- a/test/DataDiGraph_test.jl
+++ b/test/DataDiGraph_test.jl
@@ -1,5 +1,20 @@
 # Test add_node!
 nodes = [7, "node2", :node3, 17.5]
+node_data = [6.3, 7.2, 8.6, 4.3]
+
+edges = [(17.5, 7), (:node3, "node2"), (7, :node3)]
+edge_data = [2.1, 3.5, 6.8]
+
+function build_datadigraph(nodes, edges)
+    dg = DataDiGraph()
+    for i in nodes
+        add_node!(dg, i)
+    end
+    for (i, j) in edges
+        DataGraphs.add_edge!(dg, i, j)
+    end
+    return dg
+end
 
 dg = DataDiGraph()
 for i in nodes
@@ -14,8 +29,6 @@ end
 end
 
 # Test add_node_data!
-
-node_data = [6.3, 7.2, 8.6, 4.3]
 
 add_node_data!(dg, nodes[2], node_data[2], "weight")
 add_node_data!(dg, nodes[4], node_data[4], "weight")
@@ -42,8 +55,6 @@ end
 
 # Test add_edge! function 1
 
-edges = [(17.5, 7), (:node3, "node2"), (7, :node3)]
-
 for (i, j) in edges
     DataGraphs.add_edge!(dg, i, j)
 end
@@ -67,8 +78,6 @@ end
 
 # Test add_edge_data!
 
-edge_data = [2.1, 3.5, 6.8]
-
 add_edge_data!(dg, edges[3][1], edges[3][2], edge_data[3], "weight")
 add_edge_data!(dg, edges[1][1], edges[1][2], edge_data[1], "weight")
 add_edge_data!(dg, edges[2][1], edges[2][2], edge_data[2], "weight")
@@ -79,8 +88,6 @@ add_edge_data!(dg, edges[2][1], edges[2][2], edge_data[2], "weight")
 end
 
 # Test add_edge! function 2
-
-edges = [(17.5, 7), (:node3, "node2"), (7, :node3)]
 
 dg = DataDiGraph()
 for i in nodes
@@ -109,8 +116,6 @@ end
 end
 
 # Test add_edge_data! function 2
-
-edge_data = [2.1, 3.5, 6.8]
 
 add_edge_data!(dg, edges[3], edge_data[3], "weight")
 add_edge_data!(dg, edges[1], edge_data[1], "weight")

--- a/test/DataDiGraph_test.jl
+++ b/test/DataDiGraph_test.jl
@@ -2,8 +2,18 @@
 nodes = [7, "node2", :node3, 17.5]
 node_data = [6.3, 7.2, 8.6, 4.3]
 
+node_data2 = [4, 2.4]
+node_list2 = [:node3, 17.5]
+node_data3 = [17, 4, 2.2, 6]
+node_data_dict = Dict(7 => 3, "node2" => 4.2, :node3 => 1.0, 17.5 => 14.5)
+
 edges = [(17.5, 7), (:node3, "node2"), (7, :node3)]
 edge_data = [2.1, 3.5, 6.8]
+
+edge_data2 = [2.3, 4.4]
+edge_list2 = [(:node3, "node2"), (7, :node3)]
+edge_data3 = [14, 15.3, 16.4]
+edge_data_dict = Dict((17.5, 7) => .2, (:node3, "node2") => .5, (7, :node3) => .33)
 
 function build_datadigraph(nodes, edges)
     dg = DataDiGraph()
@@ -53,6 +63,40 @@ add_node_attribute!(dg, "weight2", 1.0)
     @test get_node_attributes(dg) == ["weight", "weight2"]
 end
 
+# test add_node_dataset!
+
+add_node_dataset!(dg, node_list2, node_data2, "weight2")
+add_node_dataset!(dg, node_data3, "weight3")
+add_node_dataset!(dg, node_data_dict, "weight4")
+weight_list = ["weight", "weight2", "weight3", "weight4"]
+dg2 = build_datadigraph(nodes, edges)
+dg3 = build_datadigraph(nodes, edges)
+dg4 = build_datadigraph(nodes, edges)
+add_node_dataset!(dg2, node_list2, node_data2, "weight2")
+add_node_attribute!(dg3, "weight3", 1.0)
+add_node_attribute!(dg4, "weight4", 1.0)
+add_node_dataset!(dg3, node_data3, "weight3")
+add_node_dataset!(dg4, node_data_dict, "weight4")
+
+
+@testset "add_node_dataset! test" begin
+    @test dg.node_data.attributes == weight_list
+    @test test_map(dg.node_data.attributes, dg.node_data.attribute_map)
+    @test get_node_data(dg)[:, 2][:] == [1, 1, 4, 2.4]
+    @test get_node_data(dg)[:, 3][:] == node_data3
+    @test get_node_data(dg)[:, 4][:] == [3, 4.2, 1.0, 14.5]
+    @test_throws ErrorException add_node_dataset!(dg, [:node5], [7.2], "weight5")
+    @test_throws ErrorException add_node_dataset!(dg, [:node3, "node2"], [7.2], "weight5")
+    @test_throws ErrorException add_node_dataset!(dg, [7.2, 3.4], "weight5")
+    @test_throws ErrorException add_node_dataset!(dg, Dict("node5" => 7.2), "weight5")
+    @test dg2.node_data.attributes == ["weight2"]
+    @test dg3.node_data.attributes == ["weight3"]
+    @test dg4.node_data.attributes == ["weight4"]
+    @test get_node_data(dg2)[:, 1][:] == [0.0, 0.0, 4.0, 2.4]
+    @test get_node_data(dg3)[:, 1][:] == node_data3
+    @test get_node_data(dg4)[:, 1][:] == [3, 4.2, 1.0, 14.5]
+end
+
 # Test add_edge! function 1
 
 for (i, j) in edges
@@ -89,14 +133,7 @@ end
 
 # Test add_edge! function 2
 
-dg = DataDiGraph()
-for i in nodes
-    add_node!(dg, i)
-end
-
-for i in edges
-    DataGraphs.add_edge!(dg, i)
-end
+dg = build_datadigraph(nodes, edges)
 
 @testset "add_edge! test2" begin
     @test length(dg.edges) == length(edges)
@@ -137,6 +174,36 @@ add_edge_attribute!(dg, "weight2", 1.0)
     @test all(i -> i == 1.0, get_edge_data(dg)[:, 2])
     @test_throws ErrorException add_edge_attribute!(dg, "weight", 0.0)
     @test get_edge_attributes(dg) == ["weight", "weight2"]
+end
+
+# Test add_edge_dataset!
+
+add_edge_dataset!(dg, edge_list2, edge_data2, "weight2")
+add_edge_dataset!(dg, edge_data3, "weight3")
+add_edge_dataset!(dg, edge_data_dict, "weight4")
+weight_list = ["weight", "weight2", "weight3", "weight4"]
+add_edge_dataset!(dg2, edge_list2, edge_data2, "weight2")
+add_edge_attribute!(dg3, "weight3", 1.0)
+add_edge_attribute!(dg4, "weight4", 1.0)
+add_edge_dataset!(dg3, edge_data3, "weight3")
+add_edge_dataset!(dg4, edge_data_dict, "weight4")
+
+@testset "add_edge_dataset! test" begin
+    @test dg.edge_data.attributes == weight_list
+    @test test_map(dg.node_data.attributes, dg.edge_data.attribute_map)
+    @test get_edge_data(dg)[:, 2][:] == [1.0, 2.3, 4.4]
+    @test get_edge_data(dg)[:, 3][:] == edge_data3
+    @test get_edge_data(dg)[:, 4][:] == [0.2, 0.5, 0.33]
+    @test_throws ErrorException add_edge_dataset!(dg, [(17.5, "node2")], [8.3], "weight5")
+    @test_throws ErrorException add_edge_dataset!(dg, [(17.5, 7), (7, :node3)], [8.3], "weight5")
+    @test_throws ErrorException add_edge_dataset!(dg, [8.3, 8.2], "weight5")
+    @test_throws ErrorException add_edge_dataset!(dg, Dict((:node3, 17.5) => 8.2), "weight5")
+    @test dg2.node_data.attributes == ["weight2"]
+    @test dg3.node_data.attributes == ["weight3"]
+    @test dg4.node_data.attributes == ["weight4"]
+    @test get_edge_data(dg2)[:, 1][:] == [0.0, 2.3, 4.4]
+    @test get_edge_data(dg3)[:, 1][:] == edge_data3
+    @test get_edge_data(dg4)[:, 1][:] == [0.2, 0.5, 0.33]
 end
 
 # Test adjacency matrix constructor

--- a/test/DataDiGraph_utils_test.jl
+++ b/test/DataDiGraph_utils_test.jl
@@ -52,21 +52,6 @@ agg_graph = aggregate(dg, [1, 5], "new_node")
     @test_throws ErrorException aggregate(dg, [1,5], 6)
 end
 
-@testset "pathway functions" begin
-    @test DataGraphs.has_path(dg, 1, 6)
-    @test DataGraphs.has_path(dg, 1, 4, 6)
-    @test get_path(dg, 1, 6) == [1, 4, 6]
-    @test get_path(dg, 1, 4, 6) == [1, 4, 6]
-    @test get_path(dg, 1, 6; algorithm = "BellmanFord") == [1, 4, 6]
-    @test get_path(dg, 1, 4, 6; algorithm = "BellmanFord") == [1, 4, 6]
-    @test_throws ErrorException DataGraphs.has_path(dg, 1, 7)
-    @test_throws ErrorException DataGraphs.has_path(dg, 1, 7, 4)
-    @test_throws ErrorException get_path(dg, 7, 3)
-    @test_throws ErrorException get_path(dg, 1, 3, 7)
-end
-
-@test average_degree(dg) == length(dg.edges) * 2 / length(dg.nodes)
-
 remove_node!(dg, 2)
 
 @testset "remove_node! test" begin

--- a/test/DataGraph_interface_test.jl
+++ b/test/DataGraph_interface_test.jl
@@ -22,6 +22,9 @@ end
     @test_throws ErrorException get_edge_data(dg, 1, 6, "weight")
 end
 
+rename_node_attribute!(dg, "weight", "weight1")
+rename_edge_attribute!(dg, "weight", "weight1")
+
 @testset "interface test" begin
     @test DataGraphs.ne(dg) == length(dg.edges)
     @test DataGraphs.nv(dg) == length(dg.nodes)
@@ -33,4 +36,10 @@ end
     @test !(DataGraphs.has_edge(dg, 2, 5))
     @test_throws ErrorException DataGraphs.has_edge(dg, 7, 3)
     @test_throws ErrorException DataGraphs.has_edge(dg, 3, 7)
+    @test dg.node_data.attributes == ["weight1"]
+    @test dg.node_data.attribute_map["weight1"] == 1
+    @test dg.edge_data.attributes == ["weight1"]
+    @test dg.edge_data.attribute_map["weight1"] == 1
+    @test_throws ErrorException rename_node_attribute!(dg, "wrong_weight", "weight")
+    @test_throws ErrorException rename_edge_attribute!(dg, "wrong_weight", "weight")
 end

--- a/test/DataGraph_test.jl
+++ b/test/DataGraph_test.jl
@@ -1,5 +1,31 @@
 # Test add_node!
 nodes = [7, "node2", :node3, 17.5]
+node_data = [6.3, 7.2, 8.6, 4.3]
+
+node_data2 = [4, 2.4]
+node_list2 = [:node3, 17.5]
+node_data3 = [17, 4, 2.2, 6]
+node_data_dict = Dict(7 => 3, "node2" => 4.2, :node3 => 1.0, 17.5 => 14.5)
+
+edges = [(17.5, 7), (:node3, "node2"), (7, :node3)]
+edge_data = [2.1, 3.5, 6.8]
+
+edge_data2 = [2.3, 4.4]
+edge_list2 = [(:node3, "node2"), (:node3, 7)]
+edge_data3 = [14, 15.3, 16.4]
+edge_data_dict = Dict((17.5, 7) => .2, (:node3, "node2") => .5, (7, :node3) => .33)
+
+function build_datagraph(nodes, edges)
+    dg = DataGraph()
+    for i in nodes
+        add_node!(dg, i)
+    end
+    for (i, j) in edges
+        DataGraphs.add_edge!(dg, i, j)
+    end
+
+    return dg
+end
 
 dg = DataGraph()
 for i in nodes
@@ -15,14 +41,12 @@ end
 
 # Test add_node_data!
 
-node_data = [6.3, 7.2, 8.6, 4.3]
-
 add_node_data!(dg, nodes[2], node_data[2], "weight")
 add_node_data!(dg, nodes[4], node_data[4], "weight")
 add_node_data!(dg, nodes[1], node_data[1], "weight")
 add_node_data!(dg, nodes[3], node_data[3], "weight")
 
-@testset "add_node_data!" begin
+@testset "add_node_data! test" begin
     @test dg.node_data.data[:, 1] == node_data
     @test dg.node_data.attributes == ["weight"]
 end
@@ -40,9 +64,40 @@ add_node_attribute!(dg, "weight2", 1.0)
     @test get_node_attributes(dg) == ["weight", "weight2"]
 end
 
-# Test add_edge! function 1
+# Test add_node_dataset!
 
-edges = [(17.5, 7), (:node3, "node2"), (7, :node3)]
+add_node_dataset!(dg, node_list2, node_data2, "weight2")
+add_node_dataset!(dg, node_data3, "weight3")
+add_node_dataset!(dg, node_data_dict, "weight4")
+weight_list = ["weight", "weight2", "weight3", "weight4"]
+dg2 = build_datagraph(nodes, edges)
+dg3 = build_datagraph(nodes, edges)
+dg4 = build_datagraph(nodes, edges)
+add_node_dataset!(dg2, node_list2, node_data2, "weight2")
+add_node_attribute!(dg3, "weight3", 1.0)
+add_node_attribute!(dg4, "weight4", 1.0)
+add_node_dataset!(dg3, node_data3, "weight3")
+add_node_dataset!(dg4, node_data_dict, "weight4")
+
+@testset "add_node_dataset! test" begin
+    @test dg.node_data.attributes == weight_list
+    @test test_map(dg.node_data.attributes, dg.node_data.attribute_map)
+    @test get_node_data(dg)[:, 2][:] == [1, 1, 4, 2.4]
+    @test get_node_data(dg)[:, 3][:] == node_data3
+    @test get_node_data(dg)[:, 4][:] == [3, 4.2, 1.0, 14.5]
+    @test_throws ErrorException add_node_dataset!(dg, [:node5], [7.2], "weight5")
+    @test_throws ErrorException add_node_dataset!(dg, [:node3, "node2"], [7.2], "weight5")
+    @test_throws ErrorException add_node_dataset!(dg, [7.2, 3.4], "weight5")
+    @test_throws ErrorException add_node_dataset!(dg, Dict("node5" => 7.2), "weight5")
+    @test dg2.node_data.attributes == ["weight2"]
+    @test dg3.node_data.attributes == ["weight3"]
+    @test dg4.node_data.attributes == ["weight4"]
+    @test get_node_data(dg2)[:, 1][:] == [0.0, 0.0, 4.0, 2.4]
+    @test get_node_data(dg3)[:, 1][:] == node_data3
+    @test get_node_data(dg4)[:, 1][:] == [3, 4.2, 1.0, 14.5]
+end
+
+# Test add_edge! function 1
 
 for (i, j) in edges
     DataGraphs.add_edge!(dg, i, j)
@@ -66,8 +121,6 @@ end
 end
 
 # Test add_edge_data! function 1
-
-edge_data = [2.1, 3.5, 6.8]
 
 add_edge_data!(dg, edges[3][1], edges[3][2], edge_data[3], "weight")
 add_edge_data!(dg, edges[1][1], edges[1][2], edge_data[1], "weight")
@@ -117,7 +170,6 @@ add_edge_data!(dg, edges[2], edge_data[2], "weight")
     @test dg.edge_data.attributes == ["weight"]
 end
 
-
 # Test add_edge_attribute!
 
 add_edge_attribute!(dg, "weight2", 1.0)
@@ -131,6 +183,36 @@ add_edge_attribute!(dg, "weight2", 1.0)
     @test get_edge_attributes(dg) == ["weight", "weight2"]
 end
 
+# Test add_edge_dataset!
+
+add_edge_dataset!(dg, edge_list2, edge_data2, "weight2")
+add_edge_dataset!(dg, edge_data3, "weight3")
+add_edge_dataset!(dg, edge_data_dict, "weight4")
+weight_list = ["weight", "weight2", "weight3", "weight4"]
+add_edge_dataset!(dg2, edge_list2, edge_data2, "weight2")
+add_edge_attribute!(dg3, "weight3", 1.0)
+add_edge_attribute!(dg4, "weight4", 1.0)
+add_edge_dataset!(dg3, edge_data3, "weight3")
+add_edge_dataset!(dg4, edge_data_dict, "weight4")
+
+@testset "add_edge_dataset! test" begin
+    @test dg.edge_data.attributes == weight_list
+    @test test_map(dg.node_data.attributes, dg.edge_data.attribute_map)
+    @test get_edge_data(dg)[:, 2][:] == [1.0, 2.3, 4.4]
+    @test get_edge_data(dg)[:, 3][:] == edge_data3
+    @test get_edge_data(dg)[:, 4][:] == [0.2, 0.5, 0.33]
+    @test_throws ErrorException add_edge_dataset!(dg, [(17.5, "node2")], [8.3], "weight5")
+    @test_throws ErrorException add_edge_dataset!(dg, [(17.5, 7), (7, :node3)], [8.3], "weight5")
+    @test_throws ErrorException add_edge_dataset!(dg, [8.3, 8.2], "weight5")
+    @test_throws ErrorException add_edge_dataset!(dg, Dict((:node3, 17.5) => 8.2), "weight5")
+    @test dg2.node_data.attributes == ["weight2"]
+    @test dg3.node_data.attributes == ["weight3"]
+    @test dg4.node_data.attributes == ["weight4"]
+    @test get_edge_data(dg2)[:, 1][:] == [0.0, 2.3, 4.4]
+    @test get_edge_data(dg3)[:, 1][:] == edge_data3
+    @test get_edge_data(dg4)[:, 1][:] == [0.2, 0.5, 0.33]
+end
+# Test adjacency matrix constructor
 
 adj_mat = sparse([1, 1, 2, 3, 3, 4, 2, 3, 5, 4, 5, 5],
     [2, 3, 5, 4, 5, 5, 1, 1, 2, 3, 3, 4],

--- a/test/DataGraph_test.jl
+++ b/test/DataGraph_test.jl
@@ -212,6 +212,7 @@ add_edge_dataset!(dg4, edge_data_dict, "weight4")
     @test get_edge_data(dg3)[:, 1][:] == edge_data3
     @test get_edge_data(dg4)[:, 1][:] == [0.2, 0.5, 0.33]
 end
+
 # Test adjacency matrix constructor
 
 adj_mat = sparse([1, 1, 2, 3, 3, 4, 2, 3, 5, 4, 5, 5],

--- a/test/function_tests.jl
+++ b/test/function_tests.jl
@@ -19,8 +19,6 @@ end
 
 dg = matrix_to_graph(random_matrix, true, "matrix_value")
 
-
-
 @testset "function tests" begin
     @test nodes_to_index(dg, Graphs.connected_components(dg)[1]) == Graphs.connected_components(dg.g)[1]
     @test Graphs.connected_components(ddg) == Graphs.connected_components(ddg.g)


### PR DESCRIPTION
Removed the node position attribute (from here on, DataGraphPlots and DataGraphs will not use a specific node position attribute, but instead just store the node positions as attributes in the node data). This included removing the GeometryBasics dependencies.

Added functions for adding significant amounts of node data or edge data to a graph. these functions are `add_node_dataset!` and `add_edge_dataset!` which can add vecctors or dictionaries of information to a graph. Also added accompanying tests for these functions. 