### PR TITLE
Added API for getting sets of data and for ordering edges

### DIFF
--- a/src/DataGraphs.jl
+++ b/src/DataGraphs.jl
@@ -13,7 +13,8 @@ export add_node_attribute!, add_edge_attribute!, has_edge, has_node, has_pathG
 export get_node_attributes, get_edge_attributes, get_path
 export nodes_to_index, index_to_nodes, average_degree, rename_graph_attribute!
 export rename_node_attribute!, rename_edge_attribute!, add_node_dataset!, add_edge_dataset!
-export add_graph_data!, get_graph_data, get_graph_attributes
+export add_graph_data!, get_graph_data, get_graph_attributes, order_edges!
+export get_ordered_edge_data
 
 abstract type AbstractDataGraph{T} <: Graphs.AbstractGraph{T} end
 

--- a/src/datadigraphs/interface.jl
+++ b/src/datadigraphs/interface.jl
@@ -6,7 +6,7 @@ Returns the value of attribute name on the given node
 function get_node_data(
     dg::DataDiGraph,
     node::N,
-    attribute::String=dg.node_data.attributes[1]
+    attribute::String
 ) where {N <: Any}
 
     node_map  = dg.node_map
@@ -27,7 +27,7 @@ function get_edge_data(
     dg::DataDiGraph,
     node1::N1,
     node2::N2,
-    attribute::String=dg.edge_data.attributes[1]
+    attribute::String
 ) where {N1 <: Any, N2 <: Any}
 
     edge_map  = dg.edge_map
@@ -47,7 +47,7 @@ end
 function get_edge_data(
     dg::DataDiGraph,
     edge_tuple::Tuple,
-    attribute::String=dg.edge_data.attributes[1]
+    attribute::String
 )
     return get_edge_data(dg, edge_tuple[1], edge_tuple[2], attribute)
 end

--- a/src/datadigraphs/utils.jl
+++ b/src/datadigraphs/utils.jl
@@ -1,13 +1,13 @@
 """
-    filter_nodes(datadigraph, filter_value; attribute_name)
+    filter_nodes(datadigraph, filter_value, attribute)
 
-Removes the nodes of the graph whose weight value of `attribute_name` is greater than the given
-`filter_value`. If `attribute_name` is not specified, this defaults to the first attribute within
+Removes the nodes of the graph whose weight value of `attribute` is greater than the given
+`filter_value`. If `attribute` is not specified, this defaults to the first attribute within
 the DataGraph's `NodeData`.
 """
 function filter_nodes(
     dg::DataDiGraph,
-    filter_val::R;
+    filter_val::R,
     attribute::String=dg.node_data.attributes[1]
 ) where {R <: Real}
 
@@ -49,8 +49,8 @@ function filter_nodes(
     new_edges      = Vector{Tuple{T, T}}()
     new_edge_map   = Dict{Tuple{T, T}, T}()
     old_edge_index = Vector{Int}()
-    fadjlist       = Vector{Vector{T}}([Vector{T}() for i in 1:length(new_nodes)])  ### TODO: if new_nodes is length 0, this is a vector of type any
-    badjlist       = Vector{Vector{T}}([Vector{T}() for i in 1:length(new_nodes)])  ### TODO: if new_nodes is length 0, this is a vector of type any
+    fadjlist       = [Vector{T}() for i in 1:length(new_nodes)] ## TODO: if length(new_nodes) = 0, this is a vector of type any
+    badjlist       = [Vector{T}() for i in 1:length(new_nodes)] ## TODO: if length(new_nodes) = 0, this is a vector of type any
 
     for i in 1:length(new_nodes)
         new_node_map[new_nodes[i]] = i
@@ -101,15 +101,15 @@ function filter_nodes(
 end
 
 """
-    filter_edges(datadigraph, filter_value; attribute_name)
+    filter_edges(datadigraph, filter_value, attribute)
 
-Removes the edges of the graph whose weight value of `attribute_name` is greater than the given
-`filter_value`. If `attribute_name` is not specified, this defaults to the first attribute within
+Removes the edges of the graph whose weight value of `attribute` is greater than the given
+`filter_value`. If `attribute` is not specified, this defaults to the first attribute within
 the DataGraph's `EdgeData`.
 """
 function filter_edges(
     dg::DataDiGraph,
-    filter_val::R;
+    filter_val::R,
     attribute::String = dg.edge_data.attributes[1]
 ) where {R <: Real}
 
@@ -141,8 +141,8 @@ function filter_edges(
 
     new_edge_map = Dict{Tuple{T, T}, T}()
 
-    fadjlist = Vector{Vector{T}}([Vector{T}() for i in 1:length(nodes)])   ### TODO: if new_nodes is length 0, this is a vector of type any
-    badjlist = Vector{Vector{T}}([Vector{T}() for i in 1:length(nodes)])   ### TODO: if new_nodes is length 0, this is a vector of type any
+    fadjlist = [Vector{T}() for i in 1:length(nodes)] ## TODO: if length(new_nodes) = 0, this is a vector of type any
+    badjlist = [Vector{T}() for i in 1:length(nodes)] ## TODO: if length(new_nodes) = 0, this is a vector of type any
 
     for i in 1:length(new_edges)
         new_edge_map[new_edges[i]] = i
@@ -422,8 +422,8 @@ function aggregate(
     edge_attribute_map = dg.edge_data.attribute_map
     edge_map           = dg.edge_map
 
-    fadjlist = Vector{Vector{T}}([Vector{T}() for i in 1:length(new_nodes)])   ### TODO: if new_nodes is length 0, this is a vector of type any
-    badjlist = Vector{Vector{T}}([Vector{T}() for i in 1:length(new_nodes)])   ### TODO: if new_nodes is length 0, this is a vector of type any
+    fadjlist = [Vector{T}() for i in 1:length(new_nodes)] ## TODO: if length(new_nodes) = 0, this is a vector of type any
+    badjlist = [Vector{T}() for i in 1:length(new_nodes)] ## TODO: if length(new_nodes) = 0, this is a vector of type any
 
 
     node_name_mapping   = Dict{T, Any}()

--- a/src/datagraphs/interface.jl
+++ b/src/datagraphs/interface.jl
@@ -79,25 +79,3 @@ function has_edge(
         return false
     end
 end
-
-function order_edges!(
-    dg::D
-) where {D <: DataGraphUnion}
-
-    edges = dg.edges
-    edge_map = dg.edge_map
-    edge_order = _get_edge_order(dg)
-
-    new_edges = edges[edge_order]
-
-    for (i, edge) in enumerate(new_edges)
-        edge_map[edge] = i
-    end
-
-    if length(dg.edge_data.attributes) > 0
-        edge_data = get_edge_data(dg)
-        dg.edge_data.data = edge_data[edge_order, :]
-    end
-
-    dg.edges = new_edges
-end

--- a/src/datagraphs/interface.jl
+++ b/src/datagraphs/interface.jl
@@ -79,3 +79,25 @@ function has_edge(
         return false
     end
 end
+
+function order_edges!(
+    dg::D
+) where {D <: DataGraphUnion}
+
+    edges = dg.edges
+    edge_map = dg.edge_map
+    edge_order = _get_edge_order(dg)
+
+    new_edges = edges[edge_order]
+
+    for (i, edge) in enumerate(new_edges)
+        edge_map[edge] = i
+    end
+
+    if length(dg.edge_data.attributes) > 0
+        edge_data = get_edge_data(dg)
+        dg.edge_data.data = edge_data[edge_order, :]
+    end
+
+    dg.edges = new_edges
+end

--- a/src/datagraphs/interface.jl
+++ b/src/datagraphs/interface.jl
@@ -6,7 +6,7 @@ Returns the value of attribute name on the given node
 function get_node_data(
     dg::DataGraph,
     node::N,
-    attribute::String=dg.node_data.attributes[1]
+    attribute::String
 ) where {N <: Any}
 
     node_map  = dg.node_map
@@ -27,7 +27,7 @@ function get_edge_data(
     dg::DataGraph,
     node1::N1,
     node2::N2,
-    attribute::String=dg.edge_data.attributes[1]
+    attribute::String
 ) where {N1 <: Any, N2 <: Any}
 
     edge_map  = dg.edge_map
@@ -47,7 +47,7 @@ end
 function get_edge_data(
     dg::DataGraph,
     edge_tuple::Tuple,
-    attribute::String=dg.edge_data.attributes[1]
+    attribute::String
 )
     return get_edge_data(dg, edge_tuple[1], edge_tuple[2], attribute)
 end

--- a/src/datagraphs/utils.jl
+++ b/src/datagraphs/utils.jl
@@ -367,15 +367,15 @@ function tensor_to_graph(
 end
 
 """
-    filter_nodes(datagraph, filter_value; attribute_name)
+    filter_nodes(datagraph, filter_value, attribute)
 
-Removes the nodes of the graph whose weight value of `attribute_name` is greater than the given
-`filter_value`. If `attribute_name` is not specified, this defaults to the first attribute within
+Removes the nodes of the graph whose weight value of `attribute` is greater than the given
+`filter_value`. If `attribute` is not specified, this defaults to the first attribute within
 the DataGraph's `NodeData`.
 """
 function filter_nodes(
     dg::DataGraph,
-    filter_val::R;
+    filter_val::R,
     attribute::String=dg.node_data.attributes[1]
 ) where {R <: Real}
 
@@ -416,7 +416,7 @@ function filter_nodes(
     new_edges      = Vector{Tuple{T, T}}()
     new_edge_map   = Dict{Tuple{T, T}, T}()
     old_edge_index = Vector{Int}()
-    fadjlist       = [Vector{T}() for i in 1:length(new_nodes)]  ### TODO: if new_nodes is length 0, this is a vector of type any
+    fadjlist       = [Vector{T}() for i in 1:length(new_nodes)] ## TODO: if length(new_nodes) = 0, this is a vector of type any
 
     for i in 1:length(new_nodes)
         new_node_map[new_nodes[i]] = i
@@ -467,15 +467,15 @@ function filter_nodes(
 end
 
 """
-    filter_edges(datagraph, filter_value; attribute_name)
+    filter_edges(datagraph, filter_value, attribute)
 
-Removes the edges of the graph whose weight value of `attribute_name` is greater than the given
-`filter_value`. If `attribute_name` is not specified, this defaults to the first attribute within
+Removes the edges of the graph whose weight value of `attribute` is greater than the given
+`filter_value`. If `attribute` is not specified, this defaults to the first attribute within
 the DataGraph's `EdgeData`.
 """
 function filter_edges(
     dg::DataGraph,
-    filter_val::R;
+    filter_val::R,
     attribute::String = dg.edge_data.attributes[1]
 ) where {R <: Real}
 
@@ -508,7 +508,7 @@ function filter_edges(
 
     new_edge_map = Dict{Tuple{T, T}, T}()
 
-    fadjlist = [Vector{T}() for i in 1:length(nodes)]
+    fadjlist = [Vector{T}() for i in 1:length(nodes)]  ## TODO: if length(new_nodes) = 0, this is a vector of type any
 
     for i in 1:length(new_edges)
         new_edge_map[new_edges[i]] = i
@@ -545,16 +545,16 @@ function filter_edges(
 end
 
 """
-    run_EC_on_nodes(datagraph, threshold_range; attribute_name, scale = false)
+    run_EC_on_nodes(datagraph, threshold_range, attribute, scale = false)
 
 Returns the Euler Characteristic Curve by filtering the nodes of the graph at each value in `threshold_range`
-and computing the Euler Characteristic after each filtration. If `attribute_name` is not defined, it defaults
+and computing the Euler Characteristic after each filtration. If `attribute` is not defined, it defaults
 to the first attribute in the DataGraph's `NodeData`. `scale` is a Boolean that indicates whether to scale
 the Euler Characteristic by the total number of objects (nodes + edges) in the original graph
 """
 function run_EC_on_nodes(
     dg::DataGraph,
-    thresh;
+    thresh,
     attribute::String = dg.node_data.attributes[1],
     scale::Bool = false
 )
@@ -592,16 +592,16 @@ function run_EC_on_nodes(
 end
 
 """
-    run_EC_on_edges(datagraph, threshold_range; attribute_name, scale = false)
+    run_EC_on_edges(datagraph, threshold_range, attribute, scale = false)
 
 Returns the Euler Characteristic Curve by filtering the edges of the graph at each value in `threshold_range`
-and computing the Euler Characteristic after each filtration. If `attribute_name` is not defined, it defaults
+and computing the Euler Characteristic after each filtration. If `attribute` is not defined, it defaults
 to the first attribute in the DataGraph's `EdgeData`. `scale` is a Boolean that indicates whether to scale
 the Euler Characteristic by the total number of objects (nodes + edges) in the original graph
 """
 function run_EC_on_edges(
     dg::DataGraph,
-    thresh;
+    thresh,
     attribute::String = dg.edge_data.attributes[1],
     scale::Bool = false
 )

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -470,3 +470,13 @@ function index_to_nodes(
 
     return node_list
 end
+
+function _add_data_column!(Data, attribute, default_weight)
+    M = typeof(Data.data)
+    dim1 = size(Data.data, 1)
+    push!(Data.attributes, attribute)
+    Data.attribute_map[attribute] = length(Data.attributes)
+    new_col = M(fill(default_weight, dim1, 1))
+
+    Data.data = hcat(Data.data, new_col)
+end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -507,8 +507,11 @@ Returns the ordered edge data matrix. For `DataGraph`s, this means all edges con
 `dg.nodes[1]` are ordered first, and so on. For `DataDiGraph`s, this means that all edges
 originating at `dg.nodes[1]` are ordered first, and so on for `length(dg.nodes)`
 """
-function get_ordered_edge_data(dg)
-    edge_order = get_edge_order(dg)
+function get_ordered_edge_data(
+    dg::D
+) where {D <: DataGraphUnion}
+
+    edge_order = _get_edge_order(dg)
 
     return get_edge_data(dg)[edge_order, :]
 end
@@ -521,8 +524,12 @@ For `DataGraph`s, this means all edges connected to `dg.nodes[1]` are ordered fi
 and so on. For `DataDiGraph`s, this means that all edges originating at `dg.nodes[1]`
  are ordered first, and so on for `length(dg.nodes)`
 """
-function get_ordered_edge_data(dg, attribute_list)
-    edge_order = get_edge_order(dg)
+function get_ordered_edge_data(
+    dg::D,
+    attribute_list::Vector{String}
+) where {D <: DataGraphUnion}
+
+    edge_order = _get_edge_order(dg)
 
     return get_edge_data(dg, attribute_list)[edge_order, :]
 end
@@ -535,10 +542,14 @@ For `DataGraph`s, this means all edges connected to `dg.nodes[1]` are ordered fi
 and so on. For `DataDiGraph`s, this means that all edges originating at `dg.nodes[1]`
  are ordered first, and so on for `length(dg.nodes)`
 """
-function get_ordered_edge_data(dg, attribute)
-    edge_order = get_edge_order(dg)
+function get_ordered_edge_data(
+    dg::D,
+    attribute::String
+) where {D <: DataGraphUnion}
 
-    return get_edge_data(dg, attribute)[edge_order, :]
+    edge_order = _get_edge_order(dg)
+
+    return get_edge_data(dg, attribute)[edge_order]
 end
 
 function _add_data_column!(Data, attribute, default_weight)
@@ -561,9 +572,9 @@ function _get_edge_order(
     edge_map   = dg.edge_map
 
     current_index = 1
-    for i in 1:length(nodes)
+    for i in 1:length(dg.nodes)
         fadjlist = dg.g.fadjlist[i]
-        next_index = findfirst(x -> x > i)
+        next_index = findfirst(x -> x > i, fadjlist)
         if next_index != nothing
             neighbor_list = fadjlist[next_index:length(fadjlist)]
             for j in neighbor_list
@@ -586,7 +597,7 @@ function _get_edge_order(
     edge_map   = dg.edge_map
 
     current_index = 1
-    for i in 1:length(nodes)
+    for i in 1:length(dg.nodes)
         fadjlist = dg.g.fadjlist[i]
         for j in fadjlist
             edge_order[current_index] = edge_map[(i, j)]

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -474,7 +474,7 @@ end
 """
     order_edges!(dg) where {D <: DataGraphUnion}
 
-Arranges the edges of `dg` so that they follow the order of `dg.nodes`. For `DataGraph`s, this
+Arranges in place the edges of `dg` so that they follow the order of `dg.nodes`. For `DataGraph`s, this
 means all edges connected to `dg.nodes[1]` are ordered first, and so on. For `DataDiGraph`s, this
 means that all edges originating at `dg.nodes[1]` are ordered first, and so on for `length(dg.nodes)`
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,4 +1,3 @@
-
 """
     get_node_data(dg::D) where {D <: DataGraphUnion}
 
@@ -31,6 +30,99 @@ function get_graph_data(
 ) where {D <: DataGraphUnion}
     return dg.graph_data.data
 end
+
+"""
+    get_node_data(dg::D, attribute_list) where {D <: DataGraphUnion}
+
+Returns a matrix of the node data for the attributes in attribute list in the order
+that the attributes are defined in the list
+"""
+function get_node_data(
+    dg::D,
+    attribute_list::Vector{String}
+) where {D <: DataGraphUnion}
+    node_data = get_node_data(dg)
+    attributes = dg.node_data.attributes
+    attribute_map = dg.node_data.attribute_map
+
+    if !(all(x -> x in attributes, attribute_list))
+        error("Attribute(s) in attribute_list are not defined in NodeData")
+    end
+
+    attribute_indexes = [attribute_map[i] for i in attribute_list]
+
+    return node_data[:, attribute_indexes]
+end
+
+
+"""
+    get_edge_data(dg::D, attribute_list) where {D <: DataGraphUnion}
+
+Returns a matrix of the edge data for the attributes in attribute list in the order
+that the attributes are defined in the list
+"""
+function get_edge_data(
+    dg::D,
+    attribute_list::Vector{String}
+) where {D <: DataGraphUnion}
+    edge_data = get_edge_data(dg)
+    attributes = dg.edge_data.attributes
+    attribute_map = dg.edge_data.attribute_map
+
+    if !(all(x -> x in attributes, attribute_list))
+        error("Attribute(s) in attribute_list are not defined in EdgeData")
+    end
+
+    attribute_indexes = [attribute_map[i] for i in attribute_list]
+
+    return edge_data[:, attribute_indexes]
+end
+
+"""
+    get_node_data(dg::D, attribute::String) where {D <: DataGraphUnion}
+
+Returns a vector of the edge data for the attribute
+"""
+function get_node_data(
+    dg::D,
+    attribute::String
+) where {D <: DataGraphUnion}
+    node_data = get_node_data(dg)
+    attributes = dg.node_data.attributes
+    attribute_map = dg.node_data.attribute_map
+
+    if !(attribute in attributes)
+        error("$attribute not defined for node data in datagraph")
+    end
+
+    return node_data[:, attribute_map[attribute]][:]
+end
+
+
+"""
+    get_edge_data(dg::D, attribute_list) where {D <: DataGraphUnion}
+
+Returns a vector of the edge data corresponding to the attribute
+"""
+function get_edge_data(
+    dg::D,
+    attribute::String
+) where {D <: DataGraphUnion}
+    edge_data = get_edge_data(dg)
+    attributes = dg.edge_data.attributes
+    attribute_map = dg.edge_data.attribute_map
+
+    if !(attribute in attributes)
+        error("$attribute not defined for edge data in datagraph")
+    end
+
+    return edge_data[:, attribute_map[attribute]][:]
+end
+
+### order_edge_data! - reorder all data
+### get_ordered_edge_data(graph)
+### get_ordered_edge_data(graph, attribute)
+### get_ordered_edge_data(graph, attribute_list)  -- Same for DataDiGraph
 
 """
     get_node_attributes(dg::D) where {D <: DataGraphUnion}

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -119,11 +119,6 @@ function get_edge_data(
     return edge_data[:, attribute_map[attribute]][:]
 end
 
-### order_edge_data! - reorder all data
-### get_ordered_edge_data(graph)
-### get_ordered_edge_data(graph, attribute)
-### get_ordered_edge_data(graph, attribute_list)  -- Same for DataDiGraph
-
 """
     get_node_attributes(dg::D) where {D <: DataGraphUnion}
 

--- a/test/DataDiGraph_test.jl
+++ b/test/DataDiGraph_test.jl
@@ -48,6 +48,7 @@ add_node_data!(dg, nodes[3], node_data[3], "weight")
 @testset "add_node_data! test" begin
     @test dg.node_data.data[:, 1] == node_data
     @test dg.node_data.attributes == ["weight"]
+    @test_throws ErrorException add_node_data!(dg, "node5", 5.0, "weight")
 end
 
 # Test add_node_attribute!

--- a/test/DataDiGraph_test.jl
+++ b/test/DataDiGraph_test.jl
@@ -95,6 +95,10 @@ add_node_dataset!(dg4, node_data_dict, "weight4")
     @test get_node_data(dg2)[:, 1][:] == [0.0, 0.0, 4.0, 2.4]
     @test get_node_data(dg3)[:, 1][:] == node_data3
     @test get_node_data(dg4)[:, 1][:] == [3, 4.2, 1.0, 14.5]
+    @test get_node_data(dg, ["weight", "weight4"]) == [6.3 3.0; 7.2 4.2; 8.6 1.0; 4.3 14.5]
+    @test get_node_data(dg, "weight") == [6.3, 7.2, 8.6, 4.3]
+    @test_throws ErrorException get_node_data(dg, ["weight5", "weight3"])
+    @test_throws ErrorException get_node_data(dg, "weight5")
 end
 
 # Test add_edge! function 1
@@ -204,6 +208,10 @@ add_edge_dataset!(dg4, edge_data_dict, "weight4")
     @test get_edge_data(dg2)[:, 1][:] == [0.0, 2.3, 4.4]
     @test get_edge_data(dg3)[:, 1][:] == edge_data3
     @test get_edge_data(dg4)[:, 1][:] == [0.2, 0.5, 0.33]
+    @test get_edge_data(dg, ["weight", "weight3"]) == [2.1 14.0; 3.5 15.3; 6.8 16.4]
+    @test get_edge_data(dg, "weight3") == edge_data3
+    @test_throws ErrorException get_edge_data(dg, ["weight5", "weight3"])
+    @test_throws ErrorException get_edge_data(dg, "weight5")
 end
 
 # Test graph_data

--- a/test/DataDiGraph_test.jl
+++ b/test/DataDiGraph_test.jl
@@ -214,6 +214,20 @@ add_edge_dataset!(dg4, edge_data_dict, "weight4")
     @test_throws ErrorException get_edge_data(dg, "weight5")
 end
 
+# Test edge ordering
+
+@testset "test edge ordering" begin
+    @test get_ordered_edge_data(dg) == [6.8 4.4 16.4 0.33; 3.5 2.3 15.3 0.5; 2.1 1.0 14.0 0.2]
+    @test get_ordered_edge_data(dg, ["weight3", "weight2"]) == [16.4 4.4; 15.3 2.3; 14.0 1.0]
+    @test get_ordered_edge_data(dg, "weight4") == [0.33, 0.5, 0.2]
+    order_edges!(dg)
+    @test dg.edges == [(1, 3), (3, 2), (4, 1)]
+    @test test_map(dg.edges, dg.edge_map)
+    @test get_edge_data(dg)  == [6.8 4.4 16.4 0.33; 3.5 2.3 15.3 0.5; 2.1 1.0 14.0 0.2]
+    @test get_edge_data(dg, ["weight3", "weight2"]) == [16.4 4.4; 15.3 2.3; 14.0 1.0]
+    @test get_edge_data(dg, "weight4") == [0.33, 0.5, 0.2]
+end
+
 # Test graph_data
 
 add_graph_data!(dg, 1.0, "class1")

--- a/test/DataDiGraph_utils_test.jl
+++ b/test/DataDiGraph_utils_test.jl
@@ -41,7 +41,7 @@ agg_graph = aggregate(dg, [1, 5], "new_node")
     @test length(dg.edges) - 1 == length(agg_graph.edges)
     @test test_map(agg_graph.nodes, agg_graph.node_map)
     @test test_map(agg_graph.edges, agg_graph.edge_map)
-    @test get_node_data(agg_graph, "new_node") == 1.5
+    @test get_node_data(agg_graph, "new_node", "weight") == 1.5
     @test agg_graph.g.ne == length(agg_graph.edges)
     @test (5, 2) in agg_graph.edges
     @test (5, 3) in agg_graph.edges

--- a/test/DataGraph_test.jl
+++ b/test/DataGraph_test.jl
@@ -49,6 +49,7 @@ add_node_data!(dg, nodes[3], node_data[3], "weight")
 @testset "add_node_data! test" begin
     @test dg.node_data.data[:, 1] == node_data
     @test dg.node_data.attributes == ["weight"]
+    @test_throws ErrorException add_node_data!(dg, "node5", 5.0, "weight")
 end
 
 # Test add_node_attribute!

--- a/test/DataGraph_test.jl
+++ b/test/DataGraph_test.jl
@@ -95,6 +95,10 @@ add_node_dataset!(dg4, node_data_dict, "weight4")
     @test get_node_data(dg2)[:, 1][:] == [0.0, 0.0, 4.0, 2.4]
     @test get_node_data(dg3)[:, 1][:] == node_data3
     @test get_node_data(dg4)[:, 1][:] == [3, 4.2, 1.0, 14.5]
+    @test get_node_data(dg, ["weight", "weight4"]) == [6.3 3.0; 7.2 4.2; 8.6 1.0; 4.3 14.5]
+    @test get_node_data(dg, "weight") == [6.3, 7.2, 8.6, 4.3]
+    @test_throws ErrorException get_node_data(dg, ["weight3", "weight5"])
+    @test_throws ErrorException get_node_data(dg, "weight5")
 end
 
 # Test add_edge! function 1
@@ -211,6 +215,10 @@ add_edge_dataset!(dg4, edge_data_dict, "weight4")
     @test get_edge_data(dg2)[:, 1][:] == [0.0, 2.3, 4.4]
     @test get_edge_data(dg3)[:, 1][:] == edge_data3
     @test get_edge_data(dg4)[:, 1][:] == [0.2, 0.5, 0.33]
+    @test get_edge_data(dg, ["weight", "weight3"]) == [2.1 14.0; 3.5 15.3; 6.8 16.4]
+    @test get_edge_data(dg, "weight3") == edge_data3
+    @test_throws ErrorException get_edge_data(dg, ["weight3", "weight5"])
+    @test_throws ErrorException get_edge_data(dg, "weight5")
 end
 
 # Test graph_data

--- a/test/DataGraph_test.jl
+++ b/test/DataGraph_test.jl
@@ -221,6 +221,21 @@ add_edge_dataset!(dg4, edge_data_dict, "weight4")
     @test_throws ErrorException get_edge_data(dg, "weight5")
 end
 
+# Test edge ordering
+
+@testset "test edge ordering" begin
+    @test get_ordered_edge_data(dg) == [6.8 4.4 16.4 0.33; 2.1 1.0 14.0 0.2; 3.5 2.3 15.3 0.5]
+    @test get_ordered_edge_data(dg, ["weight3", "weight2"]) == [16.4 4.4; 14.0 1.0; 15.3 2.3]
+    @test get_ordered_edge_data(dg, "weight4") == [0.33, 0.2, 0.5]
+    order_edges!(dg)
+    @test dg.edges == [(1, 3), (1, 4), (2, 3)]
+    @test test_map(dg.edges, dg.edge_map)
+    @test get_edge_data(dg)  == [6.8 4.4 16.4 0.33; 2.1 1.0 14.0 0.2; 3.5 2.3 15.3 0.5]
+    @test get_edge_data(dg, ["weight3", "weight2"]) == [16.4 4.4; 14.0 1.0; 15.3 2.3]
+    @test get_edge_data(dg, "weight4") == [0.33, 0.2, 0.5]
+end
+
+
 # Test graph_data
 
 add_graph_data!(dg, 1.0, "class1")

--- a/test/DataGraph_utils_test.jl
+++ b/test/DataGraph_utils_test.jl
@@ -161,9 +161,9 @@ agg_graph = aggregate(dg, [(2, 2), (2, 3)], "agg_node")
     @test test_map(agg_graph.nodes, agg_graph.node_map)
     @test test_map(agg_graph.edges, agg_graph.edge_map)
     @test dg.g.ne == length(dg.edges)
-    node_2_2_val = get_node_data(dg, (2, 2))
-    node_2_3_val = get_node_data(dg, (2, 3))
-    @test get_node_data(agg_graph, "agg_node") == (node_2_2_val + node_2_3_val) / 2
+    node_2_2_val = get_node_data(dg, (2, 2), "weight")
+    node_2_3_val = get_node_data(dg, (2, 3), "weight")
+    @test get_node_data(agg_graph, "agg_node", "weight") == (node_2_2_val + node_2_3_val) / 2
     @test test_edge_exists(agg_graph, (1, 2), "agg_node")
     @test test_edge_exists(agg_graph, (1, 3), "agg_node")
     @test test_edge_exists(agg_graph, (2, 1), "agg_node")


### PR DESCRIPTION
Addd `get_node_data` and `get_edge_data` functions for getting full matrices or vectors of data from the `NodeData` and `EdgeData`. 

Currently, edges are added to the `dg.edges` vector in the order they are passed to the `add_edge!` function. However, in some cases, it is valuable to sort the edges by what node they correspond to (i.e., edges connected to `dg.nodes[1]` show up first, followed by `dg.nodes[2]`, etc.). For example, this is useful in GNNs, which might take a SimpleGraph object and construct the edges in the order they appear. I added functions `order_edges! which rearranges the order of the edges in place, and I added a `get_ordered_edge_data` set of functions for returning the matrix/vector in the desired order. 