### PR TITLE
Made copies of objects when forming new graphs

### DIFF
--- a/examples/LC_on_GNNs.jl
+++ b/examples/LC_on_GNNs.jl
@@ -38,7 +38,7 @@ function getdataset()
     for i in 1:200
         datagraph = matrix_to_graph(data[i, :, :])
         gnn_graph = GNNGraph(datagraph.g,
-            ndata = get_node_data(datagraph).data'
+            ndata = get_node_data(datagraph)'
         )
         push!(graphs, gnn_graph)
     end

--- a/examples/edge_weighted_EC.jl
+++ b/examples/edge_weighted_EC.jl
@@ -19,7 +19,7 @@ for i in 1:30
     mat = abs.(data[i,:,:]) - I
     h = symmetric_matrix_to_graph(mat[:,:])
     println("built graph")
-    EC_vals = run_EC_on_edges(h, thresh, scale = true)
+    EC_vals = run_EC_on_edges(h, thresh; scale = false)
     println("Running EC")
     ECs[:,i] .= EC_vals
     println(i)

--- a/examples/picture_to_graph.jl
+++ b/examples/picture_to_graph.jl
@@ -15,13 +15,13 @@ mat = convert(Array{Float64}, imgg)
 
 # Build a graph from the array
 mat_graph = matrix_to_graph(mat)
-mat_graph.node_positions = set_matrix_node_positions!(mat_graph, mat)
+set_matrix_node_positions!(mat_graph, mat)
 
 plot_graph(mat_graph; plot_edges=false, nodesize = .5, nodestrokewidth=.001, node_z = mat_graph.node_data.data, nodecolor = :thermal)
 
 # Filter the graph
 for i in 1:3
-    @time filtered_mat_graph = filter_nodes(mat_graph, i*.125; attribute = "weight")
+    @time filtered_mat_graph = filter_nodes(mat_graph, i*.125, "weight")
     println("done with filter on $i")
     plot_graph(filtered_mat_graph, plot_edges = false, nodesize = .5)
     println("Done with $i")
@@ -31,30 +31,30 @@ end
 mat3 = channelview(img)
 
 mat_graph_R = DataGraphs.matrix_to_graph(mat3[1, :, :])
-mat_graph_R.node_positions = set_matrix_node_positions!(mat_graph_R, mat3[1, :, :])
+set_matrix_node_positions!(mat_graph_R, mat3[1, :, :])
 
 mat_graph_G = DataGraphs.matrix_to_graph(mat3[2, :, :])
-mat_graph_G.node_positions = set_matrix_node_positions!(mat_graph_G, mat3[2, :, :])
+set_matrix_node_positions!(mat_graph_G, mat3[2, :, :])
 
 mat_graph_B = DataGraphs.matrix_to_graph(mat3[3, :, :])
-mat_graph_B.node_positions = set_matrix_node_positions!(mat_graph_B, mat3[3, :, :])
+set_matrix_node_positions!(mat_graph_B, mat3[3, :, :])
 
 for i in 1:3
-    @time filtered_mat_graph = filter_nodes(mat_graph_R, i*.125; attribute = "weight")
+    @time filtered_mat_graph = filter_nodes(mat_graph_R, i*.125, attribute = "weight")
     println("done with filter on $i")
     plot_graph(filtered_mat_graph, plot_edges = false, nodesize = .5)
     println("Done with $i")
 end
 
 for i in 1:3
-    @time filtered_mat_graph = filter_nodes(mat_graph_G, i*.125; attribute = "weight")
+    @time filtered_mat_graph = filter_nodes(mat_graph_G, i*.125, attribute = "weight")
     println("done with filter on $i")
     plot_graph(filtered_mat_graph, plot_edges = false, nodesize = .5)
     println("Done with $i")
 end
 
 for i in 1:3
-    @time filtered_mat_graph = filter_nodes(mat_graph_B, i*.125; attribute = "weight")
+    @time filtered_mat_graph = filter_nodes(mat_graph_B, i*.125, attribute = "weight")
     println("done with filter on $i")
     plot_graph(filtered_mat_graph, plot_edges = false, nodesize = .5)
     println("Done with $i")

--- a/examples/tensor_to_graph.jl
+++ b/examples/tensor_to_graph.jl
@@ -14,27 +14,3 @@ xyz = rand(128, 48, 48)
 
 tensor_graph1 = tensor_to_graph(abc)
 @time tensor_graph1 = tensor_to_graph(abc)
-
-LC_path = (@__DIR__)*"/3D_LC_data.csv"
-initial_data_3D = readdlm(LC_path, ',')
-
-data_3d = Array{Float64, 4}(undef, (120, 48, 48, 3))
-
-for i in 1:120
-    for j in 1:3
-        data_3d[i, :, :, j] = initial_data_3D[(1 + (i - 1) * (48 * 3) + (j - 1) * 48):((i - 1) * (48 * 3) + j * 48), :]
-    end
-end
-
-data_3d_avg = mean(data_3d, dims=4)[:, :, :, 1]
-
-tensor_graph = tensor_to_graph(data_3d_avg)
-
-thresh =0:.002:.7
-
-ECs = run_EC_on_nodes(tensor_graph, thresh)
-@time ECs = run_EC_on_nodes(tensor_graph, thresh)
-
-using Plots; plot(thresh, ECs, legend=false)
-xlabel!("Threshold")
-ylabel!("Euler Characteristic")

--- a/src/DataGraphs.jl
+++ b/src/DataGraphs.jl
@@ -14,7 +14,7 @@ export get_node_attributes, get_edge_attributes, get_path
 export nodes_to_index, index_to_nodes, average_degree, rename_graph_attribute!
 export rename_node_attribute!, rename_edge_attribute!, add_node_dataset!, add_edge_dataset!
 export add_graph_data!, get_graph_data, get_graph_attributes, order_edges!
-export get_ordered_edge_data
+export get_ordered_edge_data, downstream_nodes, upstream_nodes
 
 abstract type AbstractDataGraph{T} <: Graphs.AbstractGraph{T} end
 

--- a/src/datadigraphs/utils.jl
+++ b/src/datadigraphs/utils.jl
@@ -1,14 +1,18 @@
 """
-    filter_nodes(datadigraph, filter_value, attribute)
+    filter_nodes(datadigraph, filter_value, attribute = dg.node_data.attributes[1]; fn = isless)
 
 Removes the nodes of the graph whose weight value of `attribute` is greater than the given
 `filter_value`. If `attribute` is not specified, this defaults to the first attribute within
 the DataGraph's `NodeData`.
+
+`fn` is a function that takes an input of two scalar values and is broadcast to the data vector.
+For example, isless, isgreater, isequal
 """
 function filter_nodes(
     dg::DataDiGraph,
     filter_val::R,
-    attribute::String=dg.node_data.attributes[1]
+    attribute::String=dg.node_data.attributes[1];
+    fn::Function = isless
 ) where {R <: Real}
 
     node_attributes    = dg.node_data.attributes
@@ -37,7 +41,7 @@ function filter_nodes(
 
     am = Graphs.LinAlg.adjacency_matrix(dg.g)
 
-    bool_vec = node_data[:, node_attribute_map[attribute]] .< filter_val
+    bool_vec = fn.(node_data[:, node_attribute_map[attribute]], filter_val)
 
     new_am = am[bool_vec, bool_vec]
 
@@ -101,16 +105,20 @@ function filter_nodes(
 end
 
 """
-    filter_edges(datadigraph, filter_value, attribute)
+    filter_edges(datadigraph, filter_value, attribute = dg.edge-data.attributes[1]; fn = isless)
 
 Removes the edges of the graph whose weight value of `attribute` is greater than the given
 `filter_value`. If `attribute` is not specified, this defaults to the first attribute within
 the DataGraph's `EdgeData`.
+
+`fn` is a function that takes an input of two scalar values and is broadcast to the data vector.
+For example, isless, isgreater, isequal
 """
 function filter_edges(
     dg::DataDiGraph,
     filter_val::R,
-    attribute::String = dg.edge_data.attributes[1]
+    attribute::String = dg.edge_data.attributes[1];
+    fn::Function = isless
 ) where {R <: Real}
 
     nodes           = dg.nodes
@@ -134,7 +142,7 @@ function filter_edges(
     M2 = typeof(get_edge_data(dg))
     T3 = eltype(get_graph_data(dg))
 
-    bool_vec = dg.edge_data.data[:, edge_attribute_map[attribute]] .< filter_val
+    bool_vec = fn.(dg.edge_data.data[:, edge_attribute_map[attribute]], filter_val)
 
     new_edges = edges[bool_vec]
     new_edge_data = edge_data[bool_vec, :]

--- a/src/datadigraphs/utils.jl
+++ b/src/datadigraphs/utils.jl
@@ -75,7 +75,7 @@ function filter_nodes(
                 index = searchsortedfirst(node_neighbors, i)
                 insert!(node_neighbors, index, i)
 
-                old_edge = _get_edge(node_map[new_nodes[i]], node_map[new_nodes[j]])
+                old_edge = (node_map[new_nodes[i]], node_map[new_nodes[j]])
                 if old_edge in edges
                     push!(old_edge_index, edge_map[old_edge])
                 end
@@ -86,7 +86,7 @@ function filter_nodes(
     if length(edge_attributes) > 0
         new_edge_data         = edge_data[old_edge_index, :]
         new_dg.edge_data.data = new_edge_data
-        new_dg.edge_data.attribute_map = dg.edge_data.attribute_map
+        new_dg.edge_data.attribute_map = copy(dg.edge_data.attribute_map)
     end
 
     simple_digraph = Graphs.SimpleDiGraph(T(length(new_edges)), fadjlist, badjlist)
@@ -96,10 +96,10 @@ function filter_nodes(
     new_dg.edges                = new_edges
     new_dg.edge_map             = new_edge_map
     new_dg.node_map             = new_node_map
-    new_dg.node_data.attributes = node_attributes
-    new_dg.edge_data.attributes = edge_attributes
+    new_dg.node_data.attributes = copy(node_attributes)
+    new_dg.edge_data.attributes = copy(edge_attributes)
     new_dg.node_data.data       = new_node_data
-    new_dg.node_data.attribute_map = dg.node_data.attribute_map
+    new_dg.node_data.attribute_map = copy(dg.node_data.attribute_map)
 
     return new_dg
 end
@@ -145,7 +145,7 @@ function filter_edges(
     bool_vec = fn.(dg.edge_data.data[:, edge_attribute_map[attribute]], filter_val)
 
     new_edges = edges[bool_vec]
-    new_edge_data = edge_data[bool_vec, :]
+    new_edge_data = copy(edge_data[bool_vec, :])
 
     new_edge_map = Dict{Tuple{T, T}, T}()
 
@@ -161,7 +161,7 @@ function filter_edges(
         index = searchsortedfirst(node_neighbors, node2)
         insert!(node_neighbors, index, node2)
 
-        @inbounds node_neighbors = fadjlist[node2]
+        @inbounds node_neighbors = badjlist[node2]
         index = searchsortedfirst(node_neighbors, node1)
         insert!(node_neighbors, index, node1)
     end
@@ -176,12 +176,12 @@ function filter_edges(
     new_dg.edge_data.data       = new_edge_data
     new_dg.node_map             = node_map
     new_dg.edge_map             = new_edge_map
-    new_dg.node_data.attributes = node_attributes
-    new_dg.edge_data.attributes = edge_attributes
+    new_dg.node_data.attributes = copy(node_attributes)
+    new_dg.edge_data.attributes = copy(edge_attributes)
     new_dg.node_data.data       = dg.node_data.data
 
-    new_dg.node_data.attribute_map = dg.node_data.attribute_map
-    new_dg.edge_data.attribute_map = dg.edge_data.attribute_map
+    new_dg.node_data.attribute_map = copy(dg.node_data.attribute_map)
+    new_dg.edge_data.attribute_map = copy(dg.edge_data.attribute_map)
 
     return new_dg
 end
@@ -419,9 +419,9 @@ function aggregate(
         node_data_to_keep = node_data[indices_to_keep, :]
         new_node_data     = vcat(node_data_to_keep, node_weight_avg)
 
-        new_dg.node_data.attributes    = node_attributes
-        new_dg.node_data.attribute_map = node_attribute_map
-        new_dg.node_data.data          = new_node_data
+        new_dg.node_data.attributes    = copy(node_attributes)
+        new_dg.node_data.attribute_map = copy(node_attribute_map)
+        new_dg.node_data.data          = copy(new_node_data)
     end
 
     edges              = dg.edges
@@ -541,9 +541,9 @@ function aggregate(
             new_edge_data[new_index, :] = edge_data_avg[:]
         end
 
-        new_dg.edge_data.attributes    = edge_attributes
-        new_dg.edge_data.attribute_map = edge_attribute_map
-        new_dg.edge_data.data           = new_edge_data
+        new_dg.edge_data.attributes    = copy(edge_attributes)
+        new_dg.edge_data.attribute_map = copy(edge_attribute_map)
+        new_dg.edge_data.data          = copy(new_edge_data)
     end
 
     simple_digraph = Graphs.SimpleDiGraph(T(length(new_edges)), fadjlist, badjlist)

--- a/src/datagraphs/utils.jl
+++ b/src/datagraphs/utils.jl
@@ -476,8 +476,8 @@ function filter_nodes(
 
     if length(edge_attributes) > 0
         new_edge_data         = edge_data[old_edge_index, :]
-        new_dg.edge_data.data = new_edge_data
-        new_dg.edge_data.attribute_map = dg.edge_data.attribute_map
+        new_dg.edge_data.data = copy(new_edge_data)
+        new_dg.edge_data.attribute_map = copy(dg.edge_data.attribute_map)
     end
 
     simple_graph = Graphs.SimpleGraph(T(length(new_edges)), fadjlist)
@@ -487,10 +487,10 @@ function filter_nodes(
     new_dg.edges                = new_edges
     new_dg.edge_map             = new_edge_map
     new_dg.node_map             = new_node_map
-    new_dg.node_data.attributes = node_attributes
-    new_dg.edge_data.attributes = edge_attributes
+    new_dg.node_data.attributes = copy(node_attributes)
+    new_dg.edge_data.attributes = copy(edge_attributes)
     new_dg.node_data.data       = new_node_data
-    new_dg.node_data.attribute_map = dg.node_data.attribute_map
+    new_dg.node_data.attribute_map = copy(dg.node_data.attribute_map)
 
     return new_dg
 end
@@ -565,14 +565,14 @@ function filter_edges(
     new_dg.nodes                = nodes
     new_dg.edges                = new_edges
     new_dg.edge_data.data       = new_edge_data
-    new_dg.node_map             = node_map
+    new_dg.node_map             = copy(node_map)
     new_dg.edge_map             = new_edge_map
-    new_dg.node_data.attributes = node_attributes
-    new_dg.edge_data.attributes = edge_attributes
-    new_dg.node_data.data       = dg.node_data.data
+    new_dg.node_data.attributes = copy(node_attributes)
+    new_dg.edge_data.attributes = copy(edge_attributes)
+    new_dg.node_data.data       = copy(dg.node_data.data)
 
-    new_dg.node_data.attribute_map = dg.node_data.attribute_map
-    new_dg.edge_data.attribute_map = dg.edge_data.attribute_map
+    new_dg.node_data.attribute_map = copy(dg.node_data.attribute_map)
+    new_dg.edge_data.attribute_map = copy(dg.edge_data.attribute_map)
 
     return new_dg
 end
@@ -879,9 +879,9 @@ function aggregate(
         node_data_to_keep = node_data[indices_to_keep, :]
         new_node_data     = vcat(node_data_to_keep, node_weight_avg)
 
-        new_dg.node_data.attributes    = node_attributes
-        new_dg.node_data.attribute_map = node_attribute_map
-        new_dg.node_data.data          = new_node_data
+        new_dg.node_data.attributes    = copy(node_attributes)
+        new_dg.node_data.attribute_map = copy(node_attribute_map)
+        new_dg.node_data.data          = copy(new_node_data)
     end
 
     edges              = dg.edges
@@ -998,9 +998,9 @@ function aggregate(
             new_edge_data[new_index, :] = edge_data_avg[:]
         end
 
-        new_dg.edge_data.attributes    = edge_attributes
-        new_dg.edge_data.attribute_map = edge_attribute_map
-        new_dg.edge_data.data           = new_edge_data
+        new_dg.edge_data.attributes    = copy(edge_attributes)
+        new_dg.edge_data.attribute_map = copy(edge_attribute_map)
+        new_dg.edge_data.data          = copy(new_edge_data)
     end
 
     simple_graph = Graphs.SimpleGraph(T(length(new_edges)), fadjlist)

--- a/src/datagraphs/utils.jl
+++ b/src/datagraphs/utils.jl
@@ -388,16 +388,20 @@ function tensor_to_graph(
 end
 
 """
-    filter_nodes(datagraph, filter_value, attribute)
+    filter_nodes(datagraph, filter_value, attribute = dg.node_data.attributes[1]; fn = isless)
 
 Removes the nodes of the graph whose weight value of `attribute` is greater than the given
 `filter_value`. If `attribute` is not specified, this defaults to the first attribute within
 the DataGraph's `NodeData`.
+
+`fn` is a function that takes an input of two scalar values and is broadcast to the data vector.
+For example, isless, isgreater, isequal
 """
 function filter_nodes(
     dg::DataGraph,
     filter_val::R,
-    attribute::String=dg.node_data.attributes[1]
+    attribute::String=dg.node_data.attributes[1];
+    fn::Function = isless
 ) where {R <: Real}
 
     node_attributes    = dg.node_data.attributes
@@ -425,7 +429,7 @@ function filter_nodes(
 
     am = Graphs.LinAlg.adjacency_matrix(dg.g)
 
-    bool_vec = node_data[:, node_attribute_map[attribute]] .< filter_val
+    bool_vec = fn.(node_data[:, node_attribute_map[attribute]], filter_val)
 
     new_am = am[bool_vec, bool_vec]
 
@@ -492,16 +496,20 @@ function filter_nodes(
 end
 
 """
-    filter_edges(datagraph, filter_value, attribute)
+    filter_edges(datagraph, filter_value, attribute = dg.edge_data.attributes[1]; fn = isless)
 
 Removes the edges of the graph whose weight value of `attribute` is greater than the given
 `filter_value`. If `attribute` is not specified, this defaults to the first attribute within
 the DataGraph's `EdgeData`.
+
+`fn` is a function that takes an input of two scalar values and is broadcast to the data vector.
+For example, isless, isgreater, isequal
 """
 function filter_edges(
     dg::DataGraph,
     filter_val::R,
-    attribute::String = dg.edge_data.attributes[1]
+    attribute::String = dg.edge_data.attributes[1];
+    fn::Function = isless
 ) where {R <: Real}
 
     nodes           = dg.nodes
@@ -526,7 +534,7 @@ function filter_edges(
 
     new_dg = DataGraph{T, T1, T2, T3, M1, M2}()
 
-    bool_vec = dg.edge_data.data[:, edge_attribute_map[attribute]] .< filter_val
+    bool_vec = fn.(dg.edge_data.data[:, edge_attribute_map[attribute]], filter_val)
 
     new_edges = edges[bool_vec]
     new_edge_data = edge_data[bool_vec, :]

--- a/src/datagraphs/utils.jl
+++ b/src/datagraphs/utils.jl
@@ -142,8 +142,8 @@ function _build_matrix_graph!(
 end
 
 """
-    matrix_to_graph(matrix, diagonal = true, attribute="weight")
-    matrix_to_graph(array_3d, diagonal = true, attribute_list = ["weight\$i" for i in 1:size(array_3d)[3]])
+    matrix_to_graph(matrix; diagonal = true, attribute="weight")
+    matrix_to_graph(array_3d; diagonal = true, attributes = ["weight\$i" for i in 1:size(array_3d)[3]])
 
 Constructs a `DataGraph` object from a matrix and saves the matrix data as node attributes under
 the name `attribute`. If `diagonal = false`, the graph has a mesh structure, where each matrix entry is represented by
@@ -155,7 +155,7 @@ the third dimension as different weights (i.e., for array of size dim1, dim2, an
 `attribute_list` can be defined by the user to give names to each weight in the third dimension.
 """
 function matrix_to_graph(
-    matrix::AbstractMatrix{T1},
+    matrix::AbstractMatrix{T1};
     diagonal::Bool = true,
     attribute::String = "weight"
 ) where {T1 <: Any}
@@ -196,9 +196,9 @@ function matrix_to_graph(
 end
 
 function matrix_to_graph(
-    array_3d::AbstractArray{T1, 3},
+    array_3d::AbstractArray{T1, 3};
     diagonal::Bool = true,
-    attribute_list::Vector{String} = ["weight$i" for i in 1:size(array_3d)[3]]
+    attributes::Vector{String} = ["weight$i" for i in 1:size(array_3d)[3]]
 ) where {T1 <: Any}
 
     dim1, dim2, dim3 = size(array_3d)
@@ -224,8 +224,8 @@ function matrix_to_graph(
 
     simple_graph = Graphs.SimpleGraph(length(edges), fadjlist)
 
-    dg.node_data.attributes = attribute_list
-    for (i, attribute) in enumerate(attribute_list)
+    dg.node_data.attributes = attributes
+    for (i, attribute) in enumerate(attributes)
         dg.node_data.attribute_map[attribute] = i
     end
 
@@ -578,7 +578,7 @@ function filter_edges(
 end
 
 """
-    run_EC_on_nodes(datagraph, threshold_range, attribute, scale = false)
+    run_EC_on_nodes(dg, threshold_range; attribute = dg.node_data.attributes[1], scale = false)
 
 Returns the Euler Characteristic Curve by filtering the nodes of the graph at each value in `threshold_range`
 and computing the Euler Characteristic after each filtration. If `attribute` is not defined, it defaults
@@ -587,7 +587,7 @@ the Euler Characteristic by the total number of objects (nodes + edges) in the o
 """
 function run_EC_on_nodes(
     dg::DataGraph,
-    thresh,
+    thresh;
     attribute::String = dg.node_data.attributes[1],
     scale::Bool = false
 )
@@ -625,7 +625,7 @@ function run_EC_on_nodes(
 end
 
 """
-    run_EC_on_edges(datagraph, threshold_range, attribute, scale = false)
+    run_EC_on_edges(dg, threshold_range; attribute = dg.edge_data.attributes[1], scale = false)
 
 Returns the Euler Characteristic Curve by filtering the edges of the graph at each value in `threshold_range`
 and computing the Euler Characteristic after each filtration. If `attribute` is not defined, it defaults
@@ -634,7 +634,7 @@ the Euler Characteristic by the total number of objects (nodes + edges) in the o
 """
 function run_EC_on_edges(
     dg::DataGraph,
-    thresh,
+    thresh;
     attribute::String = dg.edge_data.attributes[1],
     scale::Bool = false
 )

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -32,14 +32,16 @@ function get_graph_data(
 end
 
 """
-    get_node_data(dg::D, attribute_list) where {D <: DataGraphUnion}
+    get_node_data(dg::D, attribute_list; nodes = dg.nodes) where {D <: DataGraphUnion}
 
 Returns a matrix of the node data for the attributes in attribute list in the order
-that the attributes are defined in the list
+that the attributes are defined in the list. If `nodes` is defined, returns the subset
+of data corresponding to `nodes` in the order that they are defined in `nodes`
 """
 function get_node_data(
     dg::D,
-    attribute_list::Vector{String}
+    attribute_list::Vector{String};
+    nodes::Vector = dg.nodes
 ) where {D <: DataGraphUnion}
     node_data = get_node_data(dg)
     attributes = dg.node_data.attributes
@@ -49,14 +51,23 @@ function get_node_data(
         error("Attribute(s) in attribute_list are not defined in NodeData")
     end
 
+    if !(all(x -> x in dg.nodes, nodes))
+        error("Node(s) in nodes not defined in DataGraph")
+    end
+
     attribute_indexes = [attribute_map[i] for i in attribute_list]
 
-    return node_data[:, attribute_indexes]
+    if nodes == dg.nodes
+        return node_data[:, attribute_indexes]
+    else
+        node_indexes = [dg.node_map[i] for i in nodes]
+        return node_data[node_indexes, attribute_indexes]
+    end
 end
 
 
 """
-    get_edge_data(dg::D, attribute_list) where {D <: DataGraphUnion}
+    get_edge_data(dg::D, attribute_list; edges) where {D <: DataGraphUnion}
 
 Returns a matrix of the edge data for the attributes in attribute list in the order
 that the attributes are defined in the list
@@ -100,7 +111,7 @@ end
 
 
 """
-    get_edge_data(dg::D, attribute_list) where {D <: DataGraphUnion}
+    get_edge_data(dg::D, attribute) where {D <: DataGraphUnion}
 
 Returns a vector of the edge data corresponding to the attribute
 """

--- a/test/DataDiGraph_test.jl
+++ b/test/DataDiGraph_test.jl
@@ -100,6 +100,9 @@ add_node_dataset!(dg4, node_data_dict, "weight4")
     @test get_node_data(dg, "weight") == [6.3, 7.2, 8.6, 4.3]
     @test_throws ErrorException get_node_data(dg, ["weight5", "weight3"])
     @test_throws ErrorException get_node_data(dg, "weight5")
+
+    @test_throws ErrorException get_node_data(dg, ["weight3"], nodes = [1, 3, 7])
+    @test get_node_data(dg, ["weight3", "weight4"], nodes = [7, :node3]) == [17.0 3.0; 2.2 1.0]
 end
 
 # Test add_edge! function 1

--- a/test/DataGraph_test.jl
+++ b/test/DataGraph_test.jl
@@ -100,6 +100,9 @@ add_node_dataset!(dg4, node_data_dict, "weight4")
     @test get_node_data(dg, "weight") == [6.3, 7.2, 8.6, 4.3]
     @test_throws ErrorException get_node_data(dg, ["weight3", "weight5"])
     @test_throws ErrorException get_node_data(dg, "weight5")
+
+    @test_throws ErrorException get_node_data(dg, ["weight3"], nodes = [1, 3, 7])
+    @test get_node_data(dg, ["weight3", "weight4"], nodes = [7, :node3]) == [17.0 3.0; 2.2 1.0]
 end
 
 # Test add_edge! function 1

--- a/test/DataGraph_utils_test.jl
+++ b/test/DataGraph_utils_test.jl
@@ -1,7 +1,7 @@
 Random.seed!(10)
 random_matrix = rand(10, 10)
 
-dg = matrix_to_graph(random_matrix, true, "matrix_value")
+dg = matrix_to_graph(random_matrix, diagonal = true, attribute = "matrix_value")
 
 @testset "matrix_to_graph test1" begin
     @test length(dg.nodes) == 100
@@ -13,7 +13,7 @@ dg = matrix_to_graph(random_matrix, true, "matrix_value")
     @test test_map(dg.edges, dg.edge_map)
 end
 
-dg = matrix_to_graph(random_matrix, false, "matrix_value")
+dg = matrix_to_graph(random_matrix, diagonal = false, attribute = "matrix_value")
 
 @testset "matrix_to_graph test2" begin
     @test length(dg.nodes) == 100
@@ -30,7 +30,7 @@ end
 random_array = rand(10, 10, 5)
 attribute_names = ["matrix1", "matrix2", "matrix3", "matrix4", "matrix5"]
 
-dg = matrix_to_graph(random_array, true, attribute_names)
+dg = matrix_to_graph(random_array, diagonal = true, attributes = attribute_names)
 
 @testset "matrix_to_graph test3" begin
     @test length(dg.nodes) == 100
@@ -76,7 +76,7 @@ end
 
 matrix = [1 2 2; 1 1 3; 1 1 1]
 
-dg = matrix_to_graph(matrix, false)
+dg = matrix_to_graph(matrix, diagonal = false)
 
 filtered_graph = filter_nodes(dg, 2.5)
 
@@ -151,7 +151,7 @@ remove_edge!(dg, (2,1))
     @test get_edge_data(dg)[2] == 4
 end
 
-dg = matrix_to_graph(matrix, false)
+dg = matrix_to_graph(matrix, diagonal = false)
 
 agg_graph = aggregate(dg, [(2, 2), (2, 3)], "agg_node")
 

--- a/test/function_tests.jl
+++ b/test/function_tests.jl
@@ -17,7 +17,7 @@ for i in 1:length(edges)
     add_edge_data!(ddg, edges[i], edge_data[i])
 end
 
-dg = matrix_to_graph(random_matrix, true, "matrix_value")
+dg = matrix_to_graph(random_matrix, diagonal = true, attribute = "matrix_value")
 
 @testset "function tests" begin
     @test nodes_to_index(dg, Graphs.connected_components(dg)[1]) == Graphs.connected_components(dg.g)[1]
@@ -94,7 +94,7 @@ end
 @test average_degree(ddg) == length(ddg.edges) * 2 / length(ddg.nodes)
 
 matrix = [1 2 2; 1 1 3; 1 1 1]
-dg = matrix_to_graph(matrix, true)
+dg = matrix_to_graph(matrix, diagonal = true)
 
 @testset "pathway functions" begin
     @test DataGraphs.has_path(dg, (1, 1), (3, 3))

--- a/test/function_tests.jl
+++ b/test/function_tests.jl
@@ -59,6 +59,16 @@ dg = matrix_to_graph(random_matrix, true, "matrix_value")
     @test Graphs.degree_histogram(ddg) == Graphs.degree_histogram(ddg.g)
     @test Graphs.degree_centrality(dg) == Graphs.degree_centrality(dg.g)
     @test Graphs.degree_centrality(ddg) == Graphs.degree_centrality(ddg.g)
+
+    @test Graphs.clique_percolation(dg, k = 1)[1] == index_to_nodes(dg, [i for i in Graphs.clique_percolation(dg.g, k = 1)[1]])
+    @test Graphs.clique_percolation(dg)[1] == index_to_nodes(dg, [i for i in Graphs.clique_percolation(dg.g)[1]])
+
+    mc_dg = Graphs.maximal_cliques(dg)
+    mc_dgg = Graphs.maximal_cliques(dg.g)
+
+    @test length(mc_dg) == length(mc_dgg)
+    @test mc_dg[1] == index_to_nodes(dg, mc_dgg[1])
+    @test mc_dg[5] == index_to_nodes(dg, mc_dgg[5])
 end
 
 @testset "pathway functions" begin
@@ -72,6 +82,13 @@ end
     @test_throws ErrorException DataGraphs.has_path(ddg, 1, 7, 4)
     @test_throws ErrorException get_path(ddg, 7, 3)
     @test_throws ErrorException get_path(ddg, 1, 3, 7)
+
+    @test downstream_nodes(ddg, 1) == [1, 3, 4, 5, 6]
+    @test upstream_nodes(ddg, 5) == [1, 2, 4, 5]
+    @test_throws ErrorException downstream_nodes(ddg, 1, algorithm = "other")
+    @test_throws ErrorException downstream_nodes(ddg, 7)
+    @test_throws ErrorException upstream_nodes(ddg, 1, algorithm = "other")
+    @test_throws ErrorException upstream_nodes(ddg, 7)
 end
 
 @test average_degree(ddg) == length(ddg.edges) * 2 / length(ddg.nodes)


### PR DESCRIPTION
Previously, when calling `filter_edges` or `filter_nodes`, vectors, matrices, and dictionaries were not copied, meaning any changes made to the filtered graph altered the original graph. Code was updated so that now only copies of the original objects are used in the new graph. 